### PR TITLE
Enhancement: Rename Collector to Collector\DefaultCollector and extract Collector\Collector interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For a full diff see [`7afa59c...main`][7afa59c...main].
 
 * Renamed `SlowTestReporter` to `Reporter\Reporter` ([#20]), by [@localheinz]
 * Renamed `Reporter\Reporter` to `Reporter\DefaultReporter` and extracted `Reporter\Reporter` interface ([#21]), by [@localheinz]
+* Renamed `Collector` to `Collector\DefaultCollector` and extracted `Collector\Collector` interface ([#24]), by [@localheinz]
 
 [7afa59c...main]: https://github.com/ergebnis/phpunit-slow-test-detector/compare/7afa59c...main
 
@@ -38,5 +39,6 @@ For a full diff see [`7afa59c...main`][7afa59c...main].
 [#21]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/21
 [#22]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/22
 [#23]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/23
+[#24]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/24
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Collector/Collector.php
+++ b/src/Collector/Collector.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Collector;
+
+use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
+
+interface Collector
+{
+    public function collect(SlowTest $slowTest): void;
+
+    /**
+     * @phpstan-return list<SlowTest>
+     * @psalm-return list<SlowTest>
+     *
+     * @return array<int, SlowTest>
+     */
+    public function collected(): array;
+}

--- a/src/Collector/DefaultCollector.php
+++ b/src/Collector/DefaultCollector.php
@@ -11,11 +11,12 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Collector;
 
+use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
 use PHPUnit\Event;
 
-final class Collector
+final class DefaultCollector implements Collector
 {
     /**
      * @var array<string, SlowTest>

--- a/src/SlowTestCollector.php
+++ b/src/SlowTestCollector.php
@@ -21,12 +21,12 @@ final class SlowTestCollector
 
     private TimeKeeper $timer;
 
-    private Collector $collector;
+    private Collector\Collector $collector;
 
     public function __construct(
         Event\Telemetry\Duration $maximumDuration,
         TimeKeeper $timeKeeper,
-        Collector $collector
+        Collector\Collector $collector
     ) {
         $this->maximumDuration = $maximumDuration;
         $this->timer = $timeKeeper;

--- a/test/Double/Collector/AppendingCollector.php
+++ b/test/Double/Collector/AppendingCollector.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\Double\Collector;
+
+use Ergebnis\PHPUnit\SlowTestDetector\Collector\Collector;
+use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
+
+final class AppendingCollector implements Collector
+{
+    /**
+     * @phpstan-var list<SlowTest>
+     * @psalm-var list<SlowTest>
+     *
+     * @var array<int, SlowTest>
+     */
+    private array $collected = [];
+
+    public function collect(SlowTest $slowTest): void
+    {
+        $this->collected[] = $slowTest;
+    }
+
+    public function collected(): array
+    {
+        return $this->collected;
+    }
+}

--- a/test/Unit/Collector/DefaultCollectorTest.php
+++ b/test/Unit/Collector/DefaultCollectorTest.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\Unit;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\Unit\Collector;
 
-use Ergebnis\PHPUnit\SlowTestDetector\Collector;
+use Ergebnis\PHPUnit\SlowTestDetector\Collector\DefaultCollector;
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
 use Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture;
 use Ergebnis\Test\Util;
@@ -23,17 +23,17 @@ use PHPUnit\Framework;
 /**
  * @internal
  *
- * @covers \Ergebnis\PHPUnit\SlowTestDetector\Collector
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Collector\DefaultCollector
  *
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\SlowTest
  */
-final class CollectorTest extends Framework\TestCase
+final class DefaultCollectorTest extends Framework\TestCase
 {
     use Util\Helper;
 
     public function testDefaults(): void
     {
-        $collector = new Collector();
+        $collector = new DefaultCollector();
 
         self::assertSame([], $collector->collected());
     }
@@ -78,7 +78,7 @@ final class CollectorTest extends Framework\TestCase
             )
         );
 
-        $collector = new Collector();
+        $collector = new DefaultCollector();
 
         $collector->collect($first);
         $collector->collect($second);
@@ -133,7 +133,7 @@ final class CollectorTest extends Framework\TestCase
             )
         );
 
-        $collector = new Collector();
+        $collector = new DefaultCollector();
 
         $collector->collect($first);
         $collector->collect($second);
@@ -187,7 +187,7 @@ final class CollectorTest extends Framework\TestCase
             )
         );
 
-        $collector = new Collector();
+        $collector = new DefaultCollector();
 
         $collector->collect($first);
         $collector->collect($second);

--- a/test/Unit/Subscriber/TestPassedSubscriberTest.php
+++ b/test/Unit/Subscriber/TestPassedSubscriberTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Ergebnis\PHPUnit\SlowTestDetector\Test\Unit\Subscriber;
 
-use Ergebnis\PHPUnit\SlowTestDetector\Collector;
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTestCollector;
 use Ergebnis\PHPUnit\SlowTestDetector\Subscriber\TestPassedSubscriber;
+use Ergebnis\PHPUnit\SlowTestDetector\Test\Double;
 use Ergebnis\PHPUnit\SlowTestDetector\TimeKeeper;
 use Ergebnis\Test\Util;
 use PHPUnit\Event;
@@ -27,7 +27,6 @@ use PHPUnit\Framework;
  *
  * @covers \Ergebnis\PHPUnit\SlowTestDetector\Subscriber\TestPassedSubscriber
  *
- * @uses \Ergebnis\PHPUnit\SlowTestDetector\Collector
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\SlowTest
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\SlowTestCollector
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\TimeKeeper
@@ -67,7 +66,7 @@ final class TestPassedSubscriberTest extends Framework\TestCase
         $slowTestCollector = new SlowTestCollector(
             $maximumDuration,
             new TimeKeeper(),
-            new Collector()
+            new Double\Collector\AppendingCollector()
         );
 
         $slowTestCollector->testPrepared(

--- a/test/Unit/Subscriber/TestPreparedSubscriberTest.php
+++ b/test/Unit/Subscriber/TestPreparedSubscriberTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Ergebnis\PHPUnit\SlowTestDetector\Test\Unit\Subscriber;
 
-use Ergebnis\PHPUnit\SlowTestDetector\Collector;
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTestCollector;
 use Ergebnis\PHPUnit\SlowTestDetector\Subscriber\TestPreparedSubscriber;
+use Ergebnis\PHPUnit\SlowTestDetector\Test\Double;
 use Ergebnis\PHPUnit\SlowTestDetector\TimeKeeper;
 use Ergebnis\Test\Util;
 use PHPUnit\Event;
@@ -27,7 +27,6 @@ use PHPUnit\Framework;
  *
  * @covers \Ergebnis\PHPUnit\SlowTestDetector\Subscriber\TestPreparedSubscriber
  *
- * @uses \Ergebnis\PHPUnit\SlowTestDetector\Collector
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\SlowTest
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\SlowTestCollector
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\TimeKeeper
@@ -67,7 +66,7 @@ final class TestPreparedSubscriberTest extends Framework\TestCase
         $slowTestCollector = new SlowTestCollector(
             $maximumDuration,
             new TimeKeeper(),
-            new Collector()
+            new Double\Collector\AppendingCollector()
         );
 
         $subscriber = new TestPreparedSubscriber($slowTestCollector);


### PR DESCRIPTION

This pull request

* [x] renames `Collector` to `Collector\DefaultCollector` and extracts a `Collector\Collector` interface

💁‍♂️ Useful for people who prefer to implement a different collector, for example

- averaging
- minimizing

The current - default - implementation picks the slowest test run for a given test when there are multiple test runs for the same tests. This usually happens when people run tests with the `--repeat` option, for example

```
$ vendor/bin/phpunit --repeat=100
```