### PR TITLE
Enhancement: Use TimeKeeper instead of SlowTestCollector in Subscriber\TestPreparedSubscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For a full diff see [`7afa59c...main`][7afa59c...main].
 * Renamed `SlowTestReporter` to `Reporter\Reporter` ([#20]), by [@localheinz]
 * Renamed `Reporter\Reporter` to `Reporter\DefaultReporter` and extracted `Reporter\Reporter` interface ([#21]), by [@localheinz]
 * Renamed `Collector` to `Collector\DefaultCollector` and extracted `Collector\Collector` interface ([#24]), by [@localheinz]
+* Used `TimeKeeper` instead of `SlowTestCollector` in `Subscriber\TestPreparedSubscriber` ([#25]), by [@localheinz]
 
 [7afa59c...main]: https://github.com/ergebnis/phpunit-slow-test-detector/compare/7afa59c...main
 
@@ -40,5 +41,6 @@ For a full diff see [`7afa59c...main`][7afa59c...main].
 [#22]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/22
 [#23]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/23
 [#24]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/24
+[#25]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/25
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Subscriber/TestPreparedSubscriber.php
+++ b/src/Subscriber/TestPreparedSubscriber.php
@@ -13,21 +13,21 @@ declare(strict_types=1);
 
 namespace Ergebnis\PHPUnit\SlowTestDetector\Subscriber;
 
-use Ergebnis\PHPUnit\SlowTestDetector\SlowTestCollector;
+use Ergebnis\PHPUnit\SlowTestDetector\TimeKeeper;
 use PHPUnit\Event;
 
 final class TestPreparedSubscriber implements Event\Test\PreparedSubscriber
 {
-    private SlowTestCollector $slowTestCollector;
+    private TimeKeeper $timeKeeper;
 
-    public function __construct(SlowTestCollector $slowTestCollector)
+    public function __construct(TimeKeeper $timeKeeper)
     {
-        $this->slowTestCollector = $slowTestCollector;
+        $this->timeKeeper = $timeKeeper;
     }
 
     public function notify(Event\Test\Prepared $event): void
     {
-        $this->slowTestCollector->testPrepared(
+        $this->timeKeeper->start(
             $event->test(),
             $event->telemetryInfo()->time()
         );


### PR DESCRIPTION
This pull request

* [x] uses the `TimeKeeper` instead of the `SlowTestCollector` in the `Subscriber\TestPreparedSubscriber`