### PR TITLE
Enhancement: Use TimeKeeper and Collector\Collector instead of SlowTestCollector in Subscriber\TestPassedSubscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For a full diff see [`7afa59c...main`][7afa59c...main].
 * Renamed `Reporter\Reporter` to `Reporter\DefaultReporter` and extracted `Reporter\Reporter` interface ([#21]), by [@localheinz]
 * Renamed `Collector` to `Collector\DefaultCollector` and extracted `Collector\Collector` interface ([#24]), by [@localheinz]
 * Used `TimeKeeper` instead of `SlowTestCollector` in `Subscriber\TestPreparedSubscriber` ([#25]), by [@localheinz]
+* Used `TimeKeeper` and `Collector\Collector` instead of `SlowTestCollector` in `Subscriber\TestPassedSubscriber` ([#26]), by [@localheinz]
 
 [7afa59c...main]: https://github.com/ergebnis/phpunit-slow-test-detector/compare/7afa59c...main
 
@@ -42,5 +43,6 @@ For a full diff see [`7afa59c...main`][7afa59c...main].
 [#23]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/23
 [#24]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/24
 [#25]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/25
+[#26]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/26
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Subscriber/TestPassedSubscriber.php
+++ b/src/Subscriber/TestPassedSubscriber.php
@@ -13,23 +13,45 @@ declare(strict_types=1);
 
 namespace Ergebnis\PHPUnit\SlowTestDetector\Subscriber;
 
-use Ergebnis\PHPUnit\SlowTestDetector\SlowTestCollector;
+use Ergebnis\PHPUnit\SlowTestDetector\Collector;
+use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
+use Ergebnis\PHPUnit\SlowTestDetector\TimeKeeper;
 use PHPUnit\Event;
 
 final class TestPassedSubscriber implements Event\Test\PassedSubscriber
 {
-    private SlowTestCollector $slowTestCollector;
+    private Event\Telemetry\Duration $maximumDuration;
 
-    public function __construct(SlowTestCollector $slowTestCollector)
-    {
-        $this->slowTestCollector = $slowTestCollector;
+    private TimeKeeper $timeKeeper;
+
+    private Collector\Collector $collector;
+
+    public function __construct(
+        Event\Telemetry\Duration $maximumDuration,
+        TimeKeeper $timeKeeper,
+        Collector\Collector $collector
+    ) {
+        $this->maximumDuration = $maximumDuration;
+        $this->timeKeeper = $timeKeeper;
+        $this->collector = $collector;
     }
 
     public function notify(Event\Test\Passed $event): void
     {
-        $this->slowTestCollector->testPassed(
+        $duration = $this->timeKeeper->stop(
             $event->test(),
             $event->telemetryInfo()->time()
         );
+
+        if (!$duration->isGreaterThan($this->maximumDuration)) {
+            return;
+        }
+
+        $slowTest = SlowTest::fromTestAndDuration(
+            $event->test(),
+            $duration
+        );
+
+        $this->collector->collect($slowTest);
     }
 }


### PR DESCRIPTION
This pull request

* [x] uses `TimeKeeper` and `Collector\Collector` instead of `SlowTestCollector` in Subscriber\TestPassedSubscriber`