### PR TITLE
Fix: Avoid trailing new lines in report

### DIFF
--- a/src/Reporter/DefaultReporter.php
+++ b/src/Reporter/DefaultReporter.php
@@ -56,6 +56,13 @@ final class DefaultReporter implements Reporter
         $list = $this->list(...$slowTests);
         $footer = $this->footer(...$slowTests);
 
+        if ('' === $footer) {
+            return <<<TXT
+{$header}
+{$list}
+TXT;
+        }
+
         return <<<TXT
 {$header}
 {$list}

--- a/test/Unit/Reporter/DefaultReporterTest.php
+++ b/test/Unit/Reporter/DefaultReporterTest.php
@@ -168,7 +168,6 @@ Detected 5 tests that took longer than 100 ms.
  3,456 ms: Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::qux
  1,234 ms: Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::quz
    123 ms: Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::baz with dataset "string"
-
 TXT;
 
         self::assertSame($expected, $report);
@@ -259,7 +258,6 @@ Detected 5 tests that took longer than 100 ms.
  3,456 ms: Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::qux
  1,234 ms: Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::quz
    123 ms: Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::baz with dataset "string"
-
 TXT;
 
         self::assertSame($expected, $report);


### PR DESCRIPTION
This pull request

* [x] avoids trailing new lines in reports
