### PR TITLE
Fix: Account for a single slow test in report

### DIFF
--- a/src/Reporter/DefaultReporter.php
+++ b/src/Reporter/DefaultReporter.php
@@ -76,6 +76,13 @@ TXT;
 
         $formattedMaximumDuration = $this->durationFormatter->format($this->maximumDuration);
 
+        if (1 === $count) {
+            return <<<TXT
+Detected {$count} test that took longer than {$formattedMaximumDuration}.
+
+TXT;
+        }
+
         return <<<TXT
 Detected {$count} tests that took longer than {$formattedMaximumDuration}.
 

--- a/test/Unit/Reporter/DefaultReporterTest.php
+++ b/test/Unit/Reporter/DefaultReporterTest.php
@@ -81,7 +81,49 @@ final class DefaultReporterTest extends Framework\TestCase
         self::assertSame('', $report);
     }
 
-    public function testReportReturnsReportWhenTheNumberOfSlowTestsIsSmallerThanTheMaximumCount(): void
+    public function testReportReturnsReportWhenTheNumberOfSlowTestsIsSmallerThanTheMaximumCountAndLessThanOne(): void
+    {
+        $slowTests = [
+            SlowTest::fromTestAndDuration(
+                new Event\Code\Test(
+                    Example\SleeperTest::class,
+                    'foo',
+                    'foo with data set #123',
+                ),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    7,
+                    890_123_456
+                )
+            ),
+        ];
+
+        $durationFormatter = new ToMillisecondsDurationFormatter();
+
+        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            0,
+            100_000_000
+        );
+
+        $maximumNumber = \count($slowTests);
+
+        $reporter = new DefaultReporter(
+            $durationFormatter,
+            $maximumDuration,
+            $maximumNumber
+        );
+
+        $report = $reporter->report(...$slowTests);
+
+        $expected = <<<'TXT'
+Detected 1 test that took longer than 100 ms.
+
+7,890 ms: Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::foo with data set #123
+TXT;
+
+        self::assertSame($expected, $report);
+    }
+
+    public function testReportReturnsReportWhenTheNumberOfSlowTestsIsSmallerThanTheMaximumCountAndGreaterThanOne(): void
     {
         $faker = self::faker();
 


### PR DESCRIPTION
This pull request

* [x] accounts for a single slow test in the report created by the `DefaultTestReporter`