### PR TITLE
Enhancement: Compose maximum duration into SlowTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For a full diff see [`7afa59c...main`][7afa59c...main].
 * Renamed `Collector` to `Collector\DefaultCollector` and extracted `Collector\Collector` interface ([#24]), by [@localheinz]
 * Used `TimeKeeper` instead of `SlowTestCollector` in `Subscriber\TestPreparedSubscriber` ([#25]), by [@localheinz]
 * Used `TimeKeeper` and `Collector\Collector` instead of `SlowTestCollector` in `Subscriber\TestPassedSubscriber` ([#26]), by [@localheinz]
+* Composed maximum duration into `SlowTest` ([#37]), by [@localheinz]
 
 ### Removed
 
@@ -51,5 +52,6 @@ For a full diff see [`7afa59c...main`][7afa59c...main].
 [#26]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/26
 [#34]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/34
 [#36]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/36
+[#37]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/37
 
 [@localheinz]: https://github.com/localheinz

--- a/src/SlowTest.php
+++ b/src/SlowTest.php
@@ -21,21 +21,27 @@ final class SlowTest
 
     private Event\Telemetry\Duration $duration;
 
+    private Event\Telemetry\Duration $maximumDuration;
+
     private function __construct(
         Event\Code\Test $test,
-        Event\Telemetry\Duration $duration
+        Event\Telemetry\Duration $duration,
+        Event\Telemetry\Duration $maximumDuration
     ) {
         $this->test = $test;
         $this->duration = $duration;
+        $this->maximumDuration = $maximumDuration;
     }
 
-    public static function fromTestAndDuration(
+    public static function fromTestDurationAndMaximumDuration(
         Event\Code\Test $test,
-        Event\Telemetry\Duration $duration
+        Event\Telemetry\Duration $duration,
+        Event\Telemetry\Duration $maximumDuration
     ): self {
         return new self(
             $test,
-            $duration
+            $duration,
+            $maximumDuration
         );
     }
 
@@ -47,5 +53,10 @@ final class SlowTest
     public function duration(): Event\Telemetry\Duration
     {
         return $this->duration;
+    }
+
+    public function maximumDuration(): Event\Telemetry\Duration
+    {
+        return $this->maximumDuration;
     }
 }

--- a/src/Subscriber/TestPassedSubscriber.php
+++ b/src/Subscriber/TestPassedSubscriber.php
@@ -47,9 +47,10 @@ final class TestPassedSubscriber implements Event\Test\PassedSubscriber
             return;
         }
 
-        $slowTest = SlowTest::fromTestAndDuration(
+        $slowTest = SlowTest::fromTestDurationAndMaximumDuration(
             $event->test(),
-            $duration
+            $duration,
+            $this->maximumDuration
         );
 
         $this->collector->collect($slowTest);

--- a/test/Unit/Collector/DefaultCollectorTest.php
+++ b/test/Unit/Collector/DefaultCollectorTest.php
@@ -42,7 +42,7 @@ final class DefaultCollectorTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $first = SlowTest::fromTestAndDuration(
+        $first = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'foo',
@@ -51,10 +51,14 @@ final class DefaultCollectorTest extends Framework\TestCase
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),
                 $faker->numberBetween(0, 999_999_999)
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
+                $faker->numberBetween(0, 999_999_999)
             )
         );
 
-        $second = SlowTest::fromTestAndDuration(
+        $second = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'bar',
@@ -63,14 +67,22 @@ final class DefaultCollectorTest extends Framework\TestCase
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),
                 $faker->numberBetween(0, 999_999_999)
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
+                $faker->numberBetween(0, 999_999_999)
             )
         );
 
-        $third = SlowTest::fromTestAndDuration(
+        $third = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'baz',
                 'baz with data set "string"',
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
+                $faker->numberBetween(0, 999_999_999)
             ),
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),
@@ -97,7 +109,7 @@ final class DefaultCollectorTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $first = SlowTest::fromTestAndDuration(
+        $first = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'foo',
@@ -106,10 +118,14 @@ final class DefaultCollectorTest extends Framework\TestCase
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(1),
                 $faker->numberBetween(0, 999_999_999)
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
+                $faker->numberBetween(0, 999_999_999)
             )
         );
 
-        $second = SlowTest::fromTestAndDuration(
+        $second = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'bar',
@@ -118,10 +134,14 @@ final class DefaultCollectorTest extends Framework\TestCase
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),
                 $faker->numberBetween(0, 999_999_999)
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
+                $faker->numberBetween(0, 999_999_999)
             )
         );
 
-        $thirdForSameTest = SlowTest::fromTestAndDuration(
+        $thirdForSameTest = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 $first->test()->className(),
                 $first->test()->methodName(),
@@ -129,6 +149,10 @@ final class DefaultCollectorTest extends Framework\TestCase
             ),
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(0, $first->duration()->seconds() - 1),
+                $faker->numberBetween(0, 999_999_999)
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
                 $faker->numberBetween(0, 999_999_999)
             )
         );
@@ -151,7 +175,12 @@ final class DefaultCollectorTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $first = SlowTest::fromTestAndDuration(
+        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            $faker->numberBetween(),
+            $faker->numberBetween(0, 999_999_999)
+        );
+
+        $first = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'foo',
@@ -160,10 +189,11 @@ final class DefaultCollectorTest extends Framework\TestCase
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),
                 $faker->numberBetween(0, 999_999_999)
-            )
+            ),
+            $maximumDuration
         );
 
-        $second = SlowTest::fromTestAndDuration(
+        $second = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'bar',
@@ -172,10 +202,11 @@ final class DefaultCollectorTest extends Framework\TestCase
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),
                 $faker->numberBetween(0, 999_999_999)
-            )
+            ),
+            $maximumDuration
         );
 
-        $thirdForSameTest = SlowTest::fromTestAndDuration(
+        $thirdForSameTest = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 $first->test()->className(),
                 $first->test()->methodName(),
@@ -184,7 +215,8 @@ final class DefaultCollectorTest extends Framework\TestCase
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween($first->duration()->seconds() + 1),
                 $faker->numberBetween(0, 999_999_999)
-            )
+            ),
+            $maximumDuration
         );
 
         $collector = new DefaultCollector();

--- a/test/Unit/Reporter/DefaultReporterTest.php
+++ b/test/Unit/Reporter/DefaultReporterTest.php
@@ -83,8 +83,13 @@ final class DefaultReporterTest extends Framework\TestCase
 
     public function testReportReturnsReportWhenTheNumberOfSlowTestsIsSmallerThanTheMaximumCountAndLessThanOne(): void
     {
+        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            0,
+            100_000_000
+        );
+
         $slowTests = [
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'foo',
@@ -93,16 +98,12 @@ final class DefaultReporterTest extends Framework\TestCase
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     7,
                     890_123_456
-                )
+                ),
+                $maximumDuration
             ),
         ];
 
         $durationFormatter = new ToMillisecondsDurationFormatter();
-
-        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
-            0,
-            100_000_000
-        );
 
         $maximumNumber = \count($slowTests);
 
@@ -127,8 +128,13 @@ TXT;
     {
         $faker = self::faker();
 
+        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            0,
+            100_000_000
+        );
+
         $slowTests = [
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'foo',
@@ -137,9 +143,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     7,
                     890_123_456
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'bar',
@@ -148,9 +155,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     12,
                     345_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'baz',
@@ -159,9 +167,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     0,
                     123_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'qux',
@@ -170,9 +179,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     3,
                     456_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'quz',
@@ -181,16 +191,12 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     1,
                     234_000_000
-                )
+                ),
+                $maximumDuration
             ),
         ];
 
         $durationFormatter = new ToMillisecondsDurationFormatter();
-
-        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
-            0,
-            100_000_000
-        );
 
         $maximumNumber = $faker->numberBetween(\count($slowTests) + 1);
 
@@ -217,8 +223,13 @@ TXT;
 
     public function testReportReturnsReportWhenTheNumberOfSlowTestsIsEqualToTheMaximumCount(): void
     {
+        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            0,
+            100_000_000
+        );
+
         $slowTests = [
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'foo',
@@ -227,9 +238,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     7,
                     890_123_456
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'bar',
@@ -238,9 +250,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     12,
                     345_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'baz',
@@ -249,9 +262,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     0,
                     123_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'qux',
@@ -260,9 +274,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     3,
                     456_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'quz',
@@ -271,16 +286,12 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     1,
                     234_000_000
-                )
+                ),
+                $maximumDuration
             ),
         ];
 
         $durationFormatter = new ToMillisecondsDurationFormatter();
-
-        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
-            0,
-            100_000_000
-        );
 
         $maximumNumber = \count($slowTests);
 
@@ -307,8 +318,13 @@ TXT;
 
     public function testReportReturnsReportWhenTheNumberOfSlowTestsIsOneMoreThanTheMaximumCount(): void
     {
+        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            0,
+            100_000_000
+        );
+
         $slowTests = [
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'foo',
@@ -317,9 +333,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     7,
                     890_123_456
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'bar',
@@ -328,9 +345,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     12,
                     345_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'baz',
@@ -339,9 +357,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     0,
                     123_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'qux',
@@ -350,9 +369,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     3,
                     456_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'quz',
@@ -361,16 +381,12 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     1,
                     234_000_000
-                )
+                ),
+                $maximumDuration
             ),
         ];
 
         $durationFormatter = new ToMillisecondsDurationFormatter();
-
-        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
-            0,
-            100_000_000
-        );
 
         $maximumNumber = \count($slowTests) - 1;
 
@@ -398,8 +414,13 @@ TXT;
 
     public function testReportReturnsReportWhenTheNumberOfSlowTestsIsGreaterThanTheMaximumCountPlusOne(): void
     {
+        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            0,
+            100_000_000
+        );
+
         $slowTests = [
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'foo',
@@ -408,9 +429,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     7,
                     890_123_456
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'bar',
@@ -419,9 +441,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     12,
                     345_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'baz',
@@ -430,9 +453,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     0,
                     123_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'qux',
@@ -441,9 +465,10 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     3,
                     456_000_000
-                )
+                ),
+                $maximumDuration
             ),
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 new Event\Code\Test(
                     Example\SleeperTest::class,
                     'quz',
@@ -452,16 +477,12 @@ TXT;
                 Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                     1,
                     234_000_000
-                )
+                ),
+                $maximumDuration
             ),
         ];
 
         $durationFormatter = new ToMillisecondsDurationFormatter();
-
-        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
-            0,
-            100_000_000
-        );
 
         $maximumNumber = \count($slowTests) - 2;
 

--- a/test/Unit/SlowTestTest.php
+++ b/test/Unit/SlowTestTest.php
@@ -27,7 +27,7 @@ final class SlowTestTest extends Framework\TestCase
 {
     use Util\Helper;
 
-    public function testFromTestAndDurationReturnsSlowTest(): void
+    public function testFromTestDurationAndMaximumDurationReturnsSlowTest(): void
     {
         $faker = self::faker();
 
@@ -38,13 +38,16 @@ final class SlowTestTest extends Framework\TestCase
         );
 
         $duration = Event\Telemetry\Duration::fromSeconds($faker->numberBetween());
+        $maximumDuration = Event\Telemetry\Duration::fromSeconds($faker->numberBetween());
 
-        $slowTest = SlowTest::fromTestAndDuration(
+        $slowTest = SlowTest::fromTestDurationAndMaximumDuration(
             $test,
-            $duration
+            $duration,
+            $maximumDuration
         );
 
         self::assertSame($test, $slowTest->test());
         self::assertSame($duration, $slowTest->duration());
+        self::assertSame($maximumDuration, $slowTest->maximumDuration());
     }
 }

--- a/test/Unit/Subscriber/TestPassedSubscriberTest.php
+++ b/test/Unit/Subscriber/TestPassedSubscriberTest.php
@@ -230,9 +230,10 @@ final class TestPassedSubscriberTest extends Framework\TestCase
         $subscriber->notify($passedTestEvent);
 
         $expected = [
-            SlowTest::fromTestAndDuration(
+            SlowTest::fromTestDurationAndMaximumDuration(
                 $passedTest,
-                $passedTime->duration($preparedTime)
+                $passedTime->duration($preparedTime),
+                $maximumDuration
             ),
         ];
 

--- a/test/Unit/Subscriber/TestSuiteFinishedSubscriberTest.php
+++ b/test/Unit/Subscriber/TestSuiteFinishedSubscriberTest.php
@@ -84,7 +84,7 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $first = SlowTest::fromTestAndDuration(
+        $first = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'foo',
@@ -93,10 +93,14 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),
                 $faker->numberBetween(0, 999_999_999)
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
+                $faker->numberBetween(0, 999_999_999)
             )
         );
 
-        $second = SlowTest::fromTestAndDuration(
+        $second = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'bar',
@@ -105,14 +109,22 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),
                 $faker->numberBetween(0, 999_999_999)
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
+                $faker->numberBetween(0, 999_999_999)
             )
         );
 
-        $third = SlowTest::fromTestAndDuration(
+        $third = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'baz',
                 'baz with data set "string"',
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
+                $faker->numberBetween(0, 999_999_999)
             ),
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),
@@ -174,7 +186,7 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $first = SlowTest::fromTestAndDuration(
+        $first = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'foo',
@@ -183,10 +195,14 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),
                 $faker->numberBetween(0, 999_999_999)
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
+                $faker->numberBetween(0, 999_999_999)
             )
         );
 
-        $second = SlowTest::fromTestAndDuration(
+        $second = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'bar',
@@ -195,14 +211,22 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),
                 $faker->numberBetween(0, 999_999_999)
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
+                $faker->numberBetween(0, 999_999_999)
             )
         );
 
-        $third = SlowTest::fromTestAndDuration(
+        $third = SlowTest::fromTestDurationAndMaximumDuration(
             new Event\Code\Test(
                 Example\SleeperTest::class,
                 'baz',
                 'baz with data set "string"',
+            ),
+            Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                $faker->numberBetween(),
+                $faker->numberBetween(0, 999_999_999)
             ),
             Event\Telemetry\Duration::fromSecondsAndNanoseconds(
                 $faker->numberBetween(),


### PR DESCRIPTION
This pull request

* [x] composes the maximum duration into `SlowTest`

💁‍♂️ This makes sense when we start reading maximum durations from DocBlocks for tests - we can then use the specific maximum duration to render it in the report.