### PR TITLE
Enhancement: Dim maximum duration in report output

### DIFF
--- a/src/Console/Color.php
+++ b/src/Console/Color.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Console;
+
+final class Color
+{
+    /**
+     * @see https://github.com/sebastianbergmann/phpunit/blob/8.0.0/src/Util/Color.php#L109-L116
+     */
+    public static function dim(string $output): string
+    {
+        if (\trim($output) === '') {
+            return $output;
+        }
+
+        return <<<TXT
+\e[2m{$output}\e[22m
+TXT;
+    }
+}

--- a/src/Reporter/DefaultReporter.php
+++ b/src/Reporter/DefaultReporter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\PHPUnit\SlowTestDetector\Reporter;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Comparator;
+use Ergebnis\PHPUnit\SlowTestDetector\Console;
 use Ergebnis\PHPUnit\SlowTestDetector\Exception;
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
 use PHPUnit\Event;
@@ -132,12 +133,15 @@ TXT;
                 \STR_PAD_LEFT
             );
 
-            $formattedMaximumDuration = \str_pad(
-                $durationFormatter->format($slowTest->maximumDuration()),
-                $maximumDurationWidth,
-                ' ',
-                \STR_PAD_LEFT
-            );
+            $formattedMaximumDuration = Console\Color::dim(\sprintf(
+                '(%s)',
+                \str_pad(
+                    $durationFormatter->format($slowTest->maximumDuration()),
+                    $maximumDurationWidth,
+                    ' ',
+                    \STR_PAD_LEFT
+                )
+            ));
 
             $test = $slowTest->test();
 
@@ -148,7 +152,7 @@ TXT;
             );
 
             return <<<TXT
-{$formattedDuration} ({$formattedMaximumDuration}) {$testName}
+{$formattedDuration} {$formattedMaximumDuration} {$testName}
 TXT;
         }, $slowTestsToReport);
 

--- a/test/Unit/Console/ColorTest.php
+++ b/test/Unit/Console/ColorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\Unit\Console;
+
+use Ergebnis\PHPUnit\SlowTestDetector\Console\Color;
+use Ergebnis\Test\Util;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Console\Color
+ */
+final class ColorTest extends Framework\TestCase
+{
+    use Util\Helper;
+
+    /**
+     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::blank()
+     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::empty()
+     */
+    public function testDimReturnsOriginalStringWhenItIsWhitespaceOnly(string $output): void
+    {
+        self::assertSame($output, Color::dim($output));
+    }
+
+    public function testDimReturnsDimmedStringWhenItIsNotWhitespaceOnly(): void
+    {
+        $output = self::faker()->sentence;
+
+        $expected = <<<TXT
+\e[2m{$output}\e[22m
+TXT;
+        self::assertSame($expected, Color::dim($output));
+    }
+}

--- a/test/Unit/Reporter/DefaultReporterTest.php
+++ b/test/Unit/Reporter/DefaultReporterTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework;
  * @covers \Ergebnis\PHPUnit\SlowTestDetector\Reporter\DefaultReporter
  *
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\Comparator\DurationComparator
+ * @uses \Ergebnis\PHPUnit\SlowTestDetector\Console\Color
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\Exception\MaximumNumberNotGreaterThanZero
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\Formatter\ToMillisecondsDurationFormatter
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\SlowTest
@@ -118,10 +119,10 @@ final class DefaultReporterTest extends Framework\TestCase
 
         $report = $reporter->report(...$slowTests);
 
-        $expected = <<<'TXT'
+        $expected = <<<TXT
 Detected 1 test that took longer than expected.
 
-7,890 ms (3,500 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::foo with data set #123
+7,890 ms \e[2m(3,500 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::foo with data set #123
 TXT;
 
         self::assertSame($expected, $report);
@@ -214,14 +215,14 @@ TXT;
 
         $report = $reporter->report(...$slowTests);
 
-        $expected = <<<'TXT'
+        $expected = <<<TXT
 Detected 5 tests that took longer than expected.
 
-12,345 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::bar
- 7,890 ms (3,500 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::foo with data set #123
- 3,456 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::qux
- 1,234 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::quz
-   123 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::baz with dataset "string"
+12,345 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::bar
+ 7,890 ms \e[2m(3,500 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::foo with data set #123
+ 3,456 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::qux
+ 1,234 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::quz
+   123 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::baz with dataset "string"
 TXT;
 
         self::assertSame($expected, $report);
@@ -312,14 +313,14 @@ TXT;
 
         $report = $reporter->report(...$slowTests);
 
-        $expected = <<<'TXT'
+        $expected = <<<TXT
 Detected 5 tests that took longer than expected.
 
-12,345 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::bar
- 7,890 ms (3,500 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::foo with data set #123
- 3,456 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::qux
- 1,234 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::quz
-   123 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::baz with dataset "string"
+12,345 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::bar
+ 7,890 ms \e[2m(3,500 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::foo with data set #123
+ 3,456 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::qux
+ 1,234 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::quz
+   123 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::baz with dataset "string"
 TXT;
 
         self::assertSame($expected, $report);
@@ -410,13 +411,13 @@ TXT;
 
         $report = $reporter->report(...$slowTests);
 
-        $expected = <<<'TXT'
+        $expected = <<<TXT
 Detected 5 tests that took longer than expected.
 
-12,345 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::bar
- 7,890 ms (3,500 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::foo with data set #123
- 3,456 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::qux
- 1,234 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::quz
+12,345 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::bar
+ 7,890 ms \e[2m(3,500 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::foo with data set #123
+ 3,456 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::qux
+ 1,234 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::quz
 
 There is one additional slow test that is not listed here.
 TXT;
@@ -509,12 +510,12 @@ TXT;
 
         $report = $reporter->report(...$slowTests);
 
-        $expected = <<<'TXT'
+        $expected = <<<TXT
 Detected 5 tests that took longer than expected.
 
-12,345 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::bar
- 7,890 ms (3,500 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::foo with data set #123
- 3,456 ms (  100 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\Example\SleeperTest::qux
+12,345 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::bar
+ 7,890 ms \e[2m(3,500 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::foo with data set #123
+ 3,456 ms \e[2m(  100 ms)\e[22m Ergebnis\\PHPUnit\\SlowTestDetector\\Test\\Example\\SleeperTest::qux
 
 There are 2 additional slow tests that are not listed here.
 TXT;


### PR DESCRIPTION
This pull request

* [x] dims the maximum duration in the report output

### Before

![CleanShot 2021-01-26 at 00 01 04](https://user-images.githubusercontent.com/605483/105776933-c7030200-5f69-11eb-8347-7314a7721254.png)

### After

![CleanShot 2021-01-26 at 00 01 30](https://user-images.githubusercontent.com/605483/105776900-b6eb2280-5f69-11eb-871b-6e0dd3a88894.png)
