### PR TITLE
Fix: Do not use named constructor

### DIFF
--- a/src/TimeKeeper.php
+++ b/src/TimeKeeper.php
@@ -34,7 +34,10 @@ final class TimeKeeper
         $key = self::key($test);
 
         if (!\array_key_exists($key, $this->startedTimes)) {
-            return Event\Telemetry\Duration::fromSeconds(0);
+            return Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                0,
+                0
+            );
         }
 
         $startedTime = $this->startedTimes[$key];

--- a/test/Unit/Comparator/DurationComparatorTest.php
+++ b/test/Unit/Comparator/DurationComparatorTest.php
@@ -29,8 +29,15 @@ final class DurationComparatorTest extends Framework\TestCase
 
     public function testReturnsMinusOneWhenOneIsLessThanTwo(): void
     {
-        $one = Event\Telemetry\Duration::fromSeconds(5);
-        $two = Event\Telemetry\Duration::fromSeconds(6);
+        $one = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            5,
+            0
+        );
+
+        $two = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            5,
+            1
+        );
 
         $comparator = new DurationComparator();
 
@@ -39,8 +46,15 @@ final class DurationComparatorTest extends Framework\TestCase
 
     public function testReturnsZeroWhenOneEqualsTwo(): void
     {
-        $one = Event\Telemetry\Duration::fromSeconds(5);
-        $two = Event\Telemetry\Duration::fromSeconds(5);
+        $one = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            5,
+            0
+        );
+
+        $two = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            5,
+            0
+        );
 
         $comparator = new DurationComparator();
 
@@ -49,8 +63,15 @@ final class DurationComparatorTest extends Framework\TestCase
 
     public function testReturnsPlusOneWhenOneIsGreaterThanTwo(): void
     {
-        $one = Event\Telemetry\Duration::fromSeconds(5);
-        $two = Event\Telemetry\Duration::fromSeconds(4);
+        $one = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            5,
+            1
+        );
+
+        $two = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            5,
+            0
+        );
 
         $comparator = new DurationComparator();
 

--- a/test/Unit/SlowTestTest.php
+++ b/test/Unit/SlowTestTest.php
@@ -37,8 +37,14 @@ final class SlowTestTest extends Framework\TestCase
             $faker->word
         );
 
-        $duration = Event\Telemetry\Duration::fromSeconds($faker->numberBetween());
-        $maximumDuration = Event\Telemetry\Duration::fromSeconds($faker->numberBetween());
+        $duration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            $faker->numberBetween(),
+            $faker->numberBetween(0, 999_999_999)
+        );
+        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            $faker->numberBetween(),
+            $faker->numberBetween(0, 999_999_999)
+        );
 
         $slowTest = SlowTest::fromTestDurationAndMaximumDuration(
             $test,

--- a/test/Unit/Subscriber/TestPassedSubscriberTest.php
+++ b/test/Unit/Subscriber/TestPassedSubscriberTest.php
@@ -38,10 +38,10 @@ final class TestPassedSubscriberTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $maximumDuration = Event\Telemetry\Duration::fromSeconds($faker->numberBetween(
-            5,
-            10
-        ));
+        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            $faker->numberBetween(5, 10),
+            0
+        );
 
         $preparedTime = Event\Telemetry\HRTime::fromSecondsAndNanoseconds(
             $faker->numberBetween(),
@@ -72,9 +72,15 @@ final class TestPassedSubscriberTest extends Framework\TestCase
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween())
                 ),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
             ),
             $passedTest
@@ -104,10 +110,10 @@ final class TestPassedSubscriberTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $maximumDuration = Event\Telemetry\Duration::fromSeconds($faker->numberBetween(
-            5,
-            10
-        ));
+        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            $faker->numberBetween(5, 10),
+            0
+        );
 
         $preparedTime = Event\Telemetry\HRTime::fromSecondsAndNanoseconds(
             $faker->numberBetween(),
@@ -134,9 +140,15 @@ final class TestPassedSubscriberTest extends Framework\TestCase
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween())
                 ),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
             ),
             $passedTest
@@ -166,10 +178,10 @@ final class TestPassedSubscriberTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $maximumDuration = Event\Telemetry\Duration::fromSeconds($faker->numberBetween(
-            5,
-            10
-        ));
+        $maximumDuration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            $faker->numberBetween(5, 10),
+            0
+        );
 
         $preparedTime = Event\Telemetry\HRTime::fromSecondsAndNanoseconds(
             $faker->numberBetween(),
@@ -196,9 +208,15 @@ final class TestPassedSubscriberTest extends Framework\TestCase
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween())
                 ),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
             ),
             $passedTest

--- a/test/Unit/Subscriber/TestPreparedSubscriberTest.php
+++ b/test/Unit/Subscriber/TestPreparedSubscriberTest.php
@@ -54,9 +54,15 @@ final class TestPreparedSubscriberTest extends Framework\TestCase
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween())
                 ),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
             ),
             $preparedTest

--- a/test/Unit/Subscriber/TestSuiteFinishedSubscriberTest.php
+++ b/test/Unit/Subscriber/TestSuiteFinishedSubscriberTest.php
@@ -46,9 +46,15 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween())
                 ),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
             ),
             $faker->word,
@@ -142,9 +148,15 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween())
                 ),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
             ),
             $faker->word,
@@ -244,9 +256,15 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
                     Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween())
                 ),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
-                Event\Telemetry\Duration::fromSeconds($faker->numberBetween()),
+                Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+                    $faker->numberBetween(),
+                    $faker->numberBetween(0, 999_999_999)
+                ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
             ),
             $faker->word,

--- a/test/Unit/TimeKeeperTest.php
+++ b/test/Unit/TimeKeeperTest.php
@@ -50,7 +50,12 @@ final class TimeKeeperTest extends Framework\TestCase
             $stoppedTime
         );
 
-        self::assertEquals(Event\Telemetry\Duration::fromSeconds(0), $duration);
+        $expected = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            0,
+            0
+        );
+
+        self::assertEquals($expected, $duration);
     }
 
     public function testStopReturnsDurationWhenTestHasBeenStartedAndStopped(): void
@@ -136,7 +141,12 @@ final class TimeKeeperTest extends Framework\TestCase
             $secondStoppedTime
         );
 
-        self::assertEquals(Event\Telemetry\Duration::fromSeconds(0), $duration);
+        $expected = Event\Telemetry\Duration::fromSecondsAndNanoseconds(
+            0,
+            0
+        );
+
+        self::assertEquals($expected, $duration);
     }
 
     public function testCanStartAndStopMultipleTests(): void


### PR DESCRIPTION
This pull request

* [x] stops using a named constructor