### PR TITLE
Enhancement: Allow configuring maximum duration with @slowThreshold annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For a full diff see [`7afa59c...main`][7afa59c...main].
 * Added `Subscriber\TestSuiteFinishedSubscriber` ([#34]), by [@localheinz]
 * Added `MaximumDuration` ([#46]), by [@localheinz]
 * Added `MaximumCount` ([#47]), by [@localheinz]
+* Allowed configuring the maximum duration for a test with a `@slowThreshold` annotation ([#49]), by [@localheinz]
 
 ### Changed
 
@@ -59,5 +60,6 @@ For a full diff see [`7afa59c...main`][7afa59c...main].
 [#38]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/38
 [#46]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/46
 [#47]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/47
+[#49]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/49
 
 [@localheinz]: https://github.com/localheinz

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,2 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.4.1@9fd7a7d885b3a216cff8dec9d8c21a132f275224"/>
+<files psalm-version="4.4.1@9fd7a7d885b3a216cff8dec9d8c21a132f275224">
+  <file src="src/Subscriber/TestPassedSubscriber.php">
+    <InternalClass occurrences="1"/>
+    <InternalMethod occurrences="1"/>
+    <MixedArgument occurrences="1">
+      <code>$slowThreshold</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$slowThreshold</code>
+    </MixedAssignment>
+  </file>
+</files>

--- a/src/Subscriber/TestPassedSubscriber.php
+++ b/src/Subscriber/TestPassedSubscriber.php
@@ -18,6 +18,7 @@ use Ergebnis\PHPUnit\SlowTestDetector\MaximumDuration;
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
 use Ergebnis\PHPUnit\SlowTestDetector\TimeKeeper;
 use PHPUnit\Event;
+use PHPUnit\Util;
 
 final class TestPassedSubscriber implements Event\Test\PassedSubscriber
 {
@@ -44,16 +45,50 @@ final class TestPassedSubscriber implements Event\Test\PassedSubscriber
             $event->telemetryInfo()->time()
         );
 
-        if (!$duration->isGreaterThan($this->maximumDuration->toTelemetryDuration())) {
+        $maximumDuration = $this->resolveMaximumDuration($event->test());
+
+        if (!$duration->isGreaterThan($maximumDuration)) {
             return;
         }
 
         $slowTest = SlowTest::fromTestDurationAndMaximumDuration(
             $event->test(),
             $duration,
-            $this->maximumDuration->toTelemetryDuration()
+            $maximumDuration
         );
 
         $this->collector->collect($slowTest);
+    }
+
+    private function resolveMaximumDuration(Event\Code\Test $test): Event\Telemetry\Duration
+    {
+        $annotations = Util\Test::parseTestMethodAnnotations(
+            $test->className(),
+            $test->methodName()
+        );
+
+        if (!\array_key_exists('method', $annotations)) {
+            return $this->maximumDuration->toTelemetryDuration();
+        }
+
+        if (!\is_array($annotations['method'])) {
+            return $this->maximumDuration->toTelemetryDuration();
+        }
+
+        if (!\array_key_exists('slowThreshold', $annotations['method'])) {
+            return $this->maximumDuration->toTelemetryDuration();
+        }
+
+        if (!\is_array($annotations['method']['slowThreshold'])) {
+            return $this->maximumDuration->toTelemetryDuration();
+        }
+
+        $slowThreshold = \reset($annotations['method']['slowThreshold']);
+
+        if (1 !== \preg_match('/^\d+$/', $slowThreshold)) {
+            return $this->maximumDuration->toTelemetryDuration();
+        }
+
+        return MaximumDuration::fromMilliseconds((int) $slowThreshold)->toTelemetryDuration();
     }
 }

--- a/test/Example/SleeperTest.php
+++ b/test/Example/SleeperTest.php
@@ -79,4 +79,65 @@ final class SleeperTest extends Framework\TestCase
 
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
+
+    /**
+     * This DocBlock is intentionally left without a useful comment or annotation.
+     */
+    public function testSleeperSleepsWithDocBlockWithoutSlowThresholdAnnotation(): void
+    {
+        $milliseconds = 500;
+
+        $sleeper = Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    /**
+     * @slowThreshold 3.14
+     */
+    public function testSleeperSleepsWithDocBlockWithSlowThresholdAnnotationWhereValueIsNotAnInt(): void
+    {
+        $milliseconds = 500;
+
+        $sleeper = Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    /**
+     * @see https://github.com/johnkary/phpunit-speedtrap/blob/1.0/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php#L309-L331
+     *
+     * @slowThreshold 400
+     *
+     * @dataProvider provideMilliseconds
+     */
+    public function testSleeperSleepsWithSlowThresholdAnnotation(int $milliseconds): void
+    {
+        $sleeper = Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    /**
+     * @return \Generator<int, array{0: int}>
+     */
+    public function provideMilliseconds(): \Generator
+    {
+        $values = [
+            250,
+            500,
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
 }


### PR DESCRIPTION
This pull request

* [x] allows configuring the maximum duration with a `@slowThreshold` annotation on the method level

💁‍♂️ See https://github.com/johnkary/phpunit-speedtrap/tree/v3.3.0#custom-slowness-threshold-per-test-case.