### PR TITLE
Fix: Do not cache cache directory for `vimeo/psalm`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -161,13 +161,6 @@ jobs:
       - name: "Create cache directory for vimeo/psalm"
         run: "mkdir -p .build/psalm"
 
-      - name: "Cache cache directory for vimeo/psalm"
-        uses: "actions/cache@v2.1.5"
-        with:
-          path: ".build/psalm"
-          key: "php-${{ matrix.php-version }}-psalm-${{ github.sha }}"
-          restore-keys: "php-${{ matrix.php-version }}-psalm-"
-
       - name: "Run vimeo/psalm"
         run: "vendor/bin/psalm --config=psalm.xml --diff --shepherd --show-info=false --stats --threads=4"
 

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,13 @@ mutation-tests: vendor ## Runs mutation tests with infection/infection
 .PHONY: static-code-analysis
 static-code-analysis: vendor ## Runs a static code analysis with vimeo/psalm
 	mkdir -p .build/psalm
+	vendor/bin/psalm --config=psalm.xml --clear-cache
 	vendor/bin/psalm --config=psalm.xml --diff --show-info=false --stats --threads=4
 
 .PHONY: static-code-analysis-baseline
 static-code-analysis-baseline: vendor ## Generates a baseline for static code analysis with vimeo/psalm
 	mkdir -p .build/psalm
+	vendor/bin/psalm --config=psalm.xml --clear-cache
 	vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml
 
 .PHONY: tests


### PR DESCRIPTION
This pull request

* [x] stops caching the cache directory for `vimeo/psalm`