### PR TITLE
Enhancement: Use data providers provided by `ergebnis/data-provider`

### DIFF
--- a/test/Unit/Console/ColorTest.php
+++ b/test/Unit/Console/ColorTest.php
@@ -27,8 +27,8 @@ final class ColorTest extends Framework\TestCase
     use Test\Util\Helper;
 
     /**
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::blank()
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::empty()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::blank()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::empty()
      */
     public function testDimReturnsOriginalStringWhenItIsWhitespaceOnly(string $output): void
     {

--- a/test/Unit/MaximumCountTest.php
+++ b/test/Unit/MaximumCountTest.php
@@ -27,8 +27,8 @@ use PHPUnit\Framework;
 final class MaximumCountTest extends Framework\TestCase
 {
     /**
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\IntProvider::lessThanZero()
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\IntProvider::zero()
+     * @dataProvider \Ergebnis\DataProvider\IntProvider::lessThanZero()
+     * @dataProvider \Ergebnis\DataProvider\IntProvider::zero()
      */
     public function testFromIntRejectsInvalidValue(int $value): void
     {
@@ -38,7 +38,7 @@ final class MaximumCountTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\IntProvider::greaterThanZero()
+     * @dataProvider \Ergebnis\DataProvider\IntProvider::greaterThanZero()
      */
     public function testFromSecondsReturnsMaximumDuration(int $value): void
     {

--- a/test/Unit/MaximumDurationTest.php
+++ b/test/Unit/MaximumDurationTest.php
@@ -31,8 +31,8 @@ final class MaximumDurationTest extends Framework\TestCase
     use Test\Util\Helper;
 
     /**
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\IntProvider::lessThanZero()
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\IntProvider::zero()
+     * @dataProvider \Ergebnis\DataProvider\IntProvider::lessThanZero()
+     * @dataProvider \Ergebnis\DataProvider\IntProvider::zero()
      */
     public function testFromMillisecondsRejectsInvalidValue(int $milliseconds): void
     {
@@ -72,8 +72,8 @@ final class MaximumDurationTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\IntProvider::lessThanZero()
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\IntProvider::zero()
+     * @dataProvider \Ergebnis\DataProvider\IntProvider::lessThanZero()
+     * @dataProvider \Ergebnis\DataProvider\IntProvider::zero()
      */
     public function testFromSecondsRejectsInvalidValue(int $seconds): void
     {
@@ -83,7 +83,7 @@ final class MaximumDurationTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Ergebnis\Test\Util\DataProvider\IntProvider::greaterThanZero()
+     * @dataProvider \Ergebnis\DataProvider\IntProvider::greaterThanZero()
      */
     public function testFromSecondsReturnsMaximumDuration(int $seconds): void
     {


### PR DESCRIPTION
This pull request

* [x] uses data providers as provided by `ergebnis/data-provider`