### PR TITLE
Fix: Use methods instead of deprecated magic properties

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -51,9 +51,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/Unit/Console/ColorTest.php">
-    <DeprecatedMethod occurrences="1">
-      <code>sentence</code>
-    </DeprecatedMethod>
     <MixedArgument occurrences="1">
       <code>$output</code>
     </MixedArgument>
@@ -102,12 +99,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/Unit/SlowTestTest.php">
-    <DeprecatedMethod occurrences="1">
-      <code>word</code>
-    </DeprecatedMethod>
     <MixedArgument occurrences="2">
-      <code>$faker-&gt;word</code>
-      <code>$faker-&gt;word</code>
+      <code>$faker-&gt;word()</code>
+      <code>$faker-&gt;word()</code>
     </MixedArgument>
     <PropertyNotSetInConstructor occurrences="2">
       <code>SlowTestTest</code>
@@ -127,15 +121,10 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/Unit/Subscriber/TestSuiteFinishedSubscriberTest.php">
-    <DeprecatedMethod occurrences="3">
-      <code>word</code>
-      <code>word</code>
-      <code>word</code>
-    </DeprecatedMethod>
     <MixedArgument occurrences="3">
-      <code>$faker-&gt;word</code>
-      <code>$faker-&gt;word</code>
-      <code>$faker-&gt;word</code>
+      <code>$faker-&gt;word()</code>
+      <code>$faker-&gt;word()</code>
+      <code>$faker-&gt;word()</code>
     </MixedArgument>
     <PropertyNotSetInConstructor occurrences="2">
       <code>TestSuiteFinishedSubscriberTest</code>

--- a/test/Unit/Console/ColorTest.php
+++ b/test/Unit/Console/ColorTest.php
@@ -37,7 +37,7 @@ final class ColorTest extends Framework\TestCase
 
     public function testDimReturnsDimmedStringWhenItIsNotWhitespaceOnly(): void
     {
-        $output = self::faker()->sentence;
+        $output = self::faker()->sentence();
 
         $expected = <<<TXT
 \e[2m{$output}\e[22m

--- a/test/Unit/SlowTestTest.php
+++ b/test/Unit/SlowTestTest.php
@@ -33,8 +33,8 @@ final class SlowTestTest extends Framework\TestCase
 
         $test = new Event\Code\Test(
             self::class,
-            $faker->word,
-            $faker->word,
+            $faker->word(),
+            $faker->word(),
         );
 
         $duration = Event\Telemetry\Duration::fromSecondsAndNanoseconds(

--- a/test/Unit/Subscriber/TestSuiteFinishedSubscriberTest.php
+++ b/test/Unit/Subscriber/TestSuiteFinishedSubscriberTest.php
@@ -55,7 +55,7 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
                 ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
             ),
-            $faker->word,
+            $faker->word(),
             new Event\TestSuite\Result(
                 $faker->numberBetween(),
                 new Event\TestSuite\FailureCollection(),
@@ -157,7 +157,7 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
                 ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
             ),
-            $faker->word,
+            $faker->word(),
             new Event\TestSuite\Result(
                 $faker->numberBetween(),
                 new Event\TestSuite\FailureCollection(),
@@ -265,7 +265,7 @@ final class TestSuiteFinishedSubscriberTest extends Framework\TestCase
                 ),
                 Event\Telemetry\MemoryUsage::fromBytes($faker->numberBetween()),
             ),
-            $faker->word,
+            $faker->word(),
             new Event\TestSuite\Result(
                 $faker->numberBetween(),
                 new Event\TestSuite\FailureCollection(),


### PR DESCRIPTION
This pull request

* [x] uses methods instead of deprecated magic properties