### PR TITLE
Fix: Use `~` operator to limit compatibility with PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "source": "https://github.com/ergebnis/phpunit-slow-test-detector"
   },
   "require": {
-    "php": "^8.1",
+    "php": "~8.1.0 || ~8.2.0",
     "phpunit/phpunit": "dev-main#743ef0d6b as 10.0.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab5a8bb2738f98deca0256382624c7b7",
+    "content-hash": "67f0d3000b2a80333b0b5e5cfe9db204",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -2405,7 +2405,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
This pull request

- [x] uses the `~` operator to limit the compatibility with PHP versions 

Follows https://github.com/ergebnis/php-package-template/pull/1086.