### PR TITLE
Fix: Do not allow using MAXIMUM_NUMBER environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.0.0...main`][1.0.0...main].
 
+### Fixed
+
+- Removed possibility to configure maximum count of reported tests using the `MAXIMUM_NUMBER` environment variable ([#49]), by [@localheinz]
+
 ## [`1.0.0`][1.0.0]
 
 For a full diff see [`7afa59c...1.0.0`][7afa59c...1.0.0].

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -25,10 +25,6 @@ final class Extension implements Runner\Extension\Extension
     ): void {
         $maximumCount = MaximumCount::fromInt(3);
 
-        if (\is_string(\getenv('MAXIMUM_NUMBER'))) {
-            $maximumCount = MaximumCount::fromInt((int) \getenv('MAXIMUM_NUMBER'));
-        }
-
         $maximumDuration = MaximumDuration::fromMilliseconds(125);
 
         $collector = new Collector\DefaultCollector();

--- a/test/EndToEnd/MaximumNumber/ten.phpt
+++ b/test/EndToEnd/MaximumNumber/ten.phpt
@@ -30,11 +30,8 @@ Detected 8 tests that took longer than expected.
 1,0%s ms (125 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumNumber\Ten\SleeperTest::testSleeperSleepsOneSecond
   5%s ms (125 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumNumber\Ten\SleeperTest::testSleeperSleepsWithSlowThresholdAnnotation#1
   4%s ms (125 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumNumber\Ten\SleeperTest::testSleeperSleepsWithDocBlockWithSlowThresholdAnnotationWhereValueIsNotAnInt
-  4%s ms (125 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumNumber\Ten\SleeperTest::testSleeperSleepsWithDocBlockWithoutSlowThresholdAnnotation
-  3%s ms (125 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumNumber\Ten\SleeperTest::testSleeperSleepsThreeHundredMilliseconds
-  2%s ms (125 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumNumber\Ten\SleeperTest::testSleeperSleepsWithSlowThresholdAnnotation#0
-  2%s ms (125 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumNumber\Ten\SleeperTest::testSleeperSleepsTwoHundredMilliseconds
-  1%s ms (125 ms) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumNumber\Ten\SleeperTest::testSleeperSleepsOneHundredFiftyMilliseconds
+
+There are 5 additional slow tests that are not listed here.
 
 Time: %s, Memory: %s
 


### PR DESCRIPTION
This pull request

- [x] stops allowing to use the `MAXIMUM_NUMBER` environment variable to configure the maximum count of slow tests in the report

Fixes #210.