### PR TITLE
Fix: Mark classes and interfaces as internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 
 - Allowed configuring the maximum duration via `maximum-duration` parameter ([#212]), by [@localheinz]
 - Allowed configuring the maximum count via `maximum-count` parameter ([#217]), by [@localheinz]
+- Marked classes and interfaces as internal ([#219]), by [@localheinz]
 
 ### Fixed
 
@@ -82,5 +83,6 @@ For a full diff see [`7afa59c...1.0.0`][7afa59c...1.0.0].
 [#212]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/212
 [#217]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/217
 [#218]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/218
+[#219]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/219
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Collector/Collector.php
+++ b/src/Collector/Collector.php
@@ -15,6 +15,9 @@ namespace Ergebnis\PHPUnit\SlowTestDetector\Collector;
 
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
 
+/**
+ * @internal
+ */
 interface Collector
 {
     public function collect(SlowTest $slowTest): void;

--- a/src/Collector/DefaultCollector.php
+++ b/src/Collector/DefaultCollector.php
@@ -15,6 +15,9 @@ namespace Ergebnis\PHPUnit\SlowTestDetector\Collector;
 
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
 
+/**
+ * @internal
+ */
 final class DefaultCollector implements Collector
 {
     /**

--- a/src/Comparator/DurationComparator.php
+++ b/src/Comparator/DurationComparator.php
@@ -15,6 +15,9 @@ namespace Ergebnis\PHPUnit\SlowTestDetector\Comparator;
 
 use PHPUnit\Event;
 
+/**
+ * @internal
+ */
 final class DurationComparator
 {
     public function compare(

--- a/src/Console/Color.php
+++ b/src/Console/Color.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Ergebnis\PHPUnit\SlowTestDetector\Console;
 
+/**
+ * @internal
+ */
 final class Color
 {
     /**

--- a/src/Exception/InvalidMaximumCount.php
+++ b/src/Exception/InvalidMaximumCount.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Ergebnis\PHPUnit\SlowTestDetector\Exception;
 
+/**
+ * @internal
+ */
 final class InvalidMaximumCount extends \InvalidArgumentException
 {
     public static function notGreaterThanZero(int $value): self

--- a/src/Exception/InvalidMaximumDuration.php
+++ b/src/Exception/InvalidMaximumDuration.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Ergebnis\PHPUnit\SlowTestDetector\Exception;
 
+/**
+ * @internal
+ */
 final class InvalidMaximumDuration extends \InvalidArgumentException
 {
     public static function notGreaterThanZero(int $value): self

--- a/src/Formatter/DurationFormatter.php
+++ b/src/Formatter/DurationFormatter.php
@@ -15,6 +15,9 @@ namespace Ergebnis\PHPUnit\SlowTestDetector\Formatter;
 
 use PHPUnit\Event;
 
+/**
+ * @internal
+ */
 interface DurationFormatter
 {
     public function format(Event\Telemetry\Duration $duration): string;

--- a/src/Formatter/ToMillisecondsDurationFormatter.php
+++ b/src/Formatter/ToMillisecondsDurationFormatter.php
@@ -16,6 +16,8 @@ namespace Ergebnis\PHPUnit\SlowTestDetector\Formatter;
 use PHPUnit\Event;
 
 /**
+ * @internal
+ *
  * @psalm-immutable
  */
 final class ToMillisecondsDurationFormatter implements DurationFormatter

--- a/src/MaximumCount.php
+++ b/src/MaximumCount.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Ergebnis\PHPUnit\SlowTestDetector;
 
 /**
+ * @internal
+ *
  * @psalm-immutable
  */
 final class MaximumCount

--- a/src/MaximumDuration.php
+++ b/src/MaximumDuration.php
@@ -16,6 +16,8 @@ namespace Ergebnis\PHPUnit\SlowTestDetector;
 use PHPUnit\Event;
 
 /**
+ * @internal
+ *
  * @psalm-immutable
  */
 final class MaximumDuration

--- a/src/Reporter/DefaultReporter.php
+++ b/src/Reporter/DefaultReporter.php
@@ -20,6 +20,9 @@ use Ergebnis\PHPUnit\SlowTestDetector\MaximumDuration;
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
 use PHPUnit\Event;
 
+/**
+ * @internal
+ */
 final class DefaultReporter implements Reporter
 {
     private readonly Comparator\DurationComparator $durationComparator;

--- a/src/Reporter/Reporter.php
+++ b/src/Reporter/Reporter.php
@@ -15,6 +15,9 @@ namespace Ergebnis\PHPUnit\SlowTestDetector\Reporter;
 
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
 
+/**
+ * @internal
+ */
 interface Reporter
 {
     public function report(SlowTest ...$slowTests): string;

--- a/src/SlowTest.php
+++ b/src/SlowTest.php
@@ -16,6 +16,8 @@ namespace Ergebnis\PHPUnit\SlowTestDetector;
 use PHPUnit\Event;
 
 /**
+ * @internal
+ *
  * @psalm-immutable
  */
 final class SlowTest

--- a/src/Subscriber/TestPassedSubscriber.php
+++ b/src/Subscriber/TestPassedSubscriber.php
@@ -20,6 +20,9 @@ use Ergebnis\PHPUnit\SlowTestDetector\TimeKeeper;
 use PHPUnit\Event;
 use PHPUnit\Metadata;
 
+/**
+ * @internal
+ */
 final class TestPassedSubscriber implements Event\Test\PassedSubscriber
 {
     public function __construct(

--- a/src/Subscriber/TestPreparedSubscriber.php
+++ b/src/Subscriber/TestPreparedSubscriber.php
@@ -16,6 +16,9 @@ namespace Ergebnis\PHPUnit\SlowTestDetector\Subscriber;
 use Ergebnis\PHPUnit\SlowTestDetector\TimeKeeper;
 use PHPUnit\Event;
 
+/**
+ * @internal
+ */
 final class TestPreparedSubscriber implements Event\Test\PreparedSubscriber
 {
     public function __construct(private readonly TimeKeeper $timeKeeper)

--- a/src/Subscriber/TestRunnerExecutionFinishedSubscriber.php
+++ b/src/Subscriber/TestRunnerExecutionFinishedSubscriber.php
@@ -17,6 +17,9 @@ use Ergebnis\PHPUnit\SlowTestDetector\Collector;
 use Ergebnis\PHPUnit\SlowTestDetector\Reporter;
 use PHPUnit\Event;
 
+/**
+ * @internal
+ */
 final class TestRunnerExecutionFinishedSubscriber implements Event\TestRunner\ExecutionFinishedSubscriber
 {
     public function __construct(

--- a/src/TimeKeeper.php
+++ b/src/TimeKeeper.php
@@ -15,6 +15,9 @@ namespace Ergebnis\PHPUnit\SlowTestDetector;
 
 use PHPUnit\Event;
 
+/**
+ * @internal
+ */
 final class TimeKeeper
 {
     /**


### PR DESCRIPTION
This pull request

- [x] marks classes and interfaces as internal
