### PR TITLE
Fix: Resolve maximum duration from `@slowThreshold` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 
 - Removed possibility to configure maximum count of reported tests using the `MAXIMUM_NUMBER` environment variable ([#211]), by [@localheinz]
 - Increased default maximum count from `3` to `10` and default maximum duration from `125` to `500` milliseconds ([#218]), by [@localheinz]
+- Fixed resolving maximum duration from `@slowThreshold` annotation ([#221]), by [@localheinz]
+
 
 ## [`1.0.0`][1.0.0]
 

--- a/src/Subscriber/TestPassedSubscriber.php
+++ b/src/Subscriber/TestPassedSubscriber.php
@@ -64,23 +64,15 @@ final class TestPassedSubscriber implements Event\Test\PassedSubscriber
 
         $annotations = $docBlock->symbolAnnotations();
 
-        if (!\array_key_exists('method', $annotations)) {
+        if (!\array_key_exists('slowThreshold', $annotations)) {
             return $this->maximumDuration->toTelemetryDuration();
         }
 
-        if (!\is_array($annotations['method'])) {
+        if (!\is_array($annotations['slowThreshold'])) {
             return $this->maximumDuration->toTelemetryDuration();
         }
 
-        if (!\array_key_exists('slowThreshold', $annotations['method'])) {
-            return $this->maximumDuration->toTelemetryDuration();
-        }
-
-        if (!\is_array($annotations['method']['slowThreshold'])) {
-            return $this->maximumDuration->toTelemetryDuration();
-        }
-
-        $slowThreshold = \reset($annotations['method']['slowThreshold']);
+        $slowThreshold = \reset($annotations['slowThreshold']);
 
         if (1 !== \preg_match('/^\d+$/', $slowThreshold)) {
             return $this->maximumDuration->toTelemetryDuration();

--- a/test/EndToEnd/MaximumDuration/Fifty/test.phpt
+++ b/test/EndToEnd/MaximumDuration/Fifty/test.phpt
@@ -23,11 +23,10 @@ Random Seed:   %s
 
 .......                                                             7 / 7 (100%)
 
-Detected 5 tests that took longer than expected.
+Detected 4 tests that took longer than expected.
 
-0.1%s (0.050) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumDuration\Fifty\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromSlowThresholdAnnotation
+0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumDuration\Fifty\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromSlowThresholdAnnotation
 0.1%s (0.050) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumDuration\Fifty\SleeperTest::testSleeperSleepsWithDocBlockWithSlowThresholdAnnotationWhereValueIsNotAnInt
-0.0%s (0.050) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumDuration\Fifty\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromSlowThresholdAnnotation
 0.0%s (0.050) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumDuration\Fifty\SleeperTest::testSleeperSleepsWithDocBlockWithoutSlowThresholdAnnotation
 0.0%s (0.050) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\MaximumDuration\Fifty\SleeperTest::testSleeperSleepsJustAboveDefaultMaximumDuration
 


### PR DESCRIPTION
This pull request

- [x] correctly resolves the maximum duration from `@slowThreshold` annotations