### PR TITLE
Fix: Do not register extension when running `phpunit` with the `--no-output` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.1.0...main`][2.1.0...main].
 
+### Fixed
+
+- Stopped registering extension when running `phpunit` with the `--no-output` option ([#243]), by [@localheinz]
+
 ## [`2.1.0`][2.1.0]
 
 For a full diff see [`2.0.0...2.1.0`][2.0.0...2.1.0].
@@ -107,5 +111,6 @@ For a full diff see [`7afa59c...1.0.0`][7afa59c...1.0.0].
 [#221]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/221
 [#222]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/222
 [#224]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/224
+[#243]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/243
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -23,6 +23,10 @@ final class Extension implements Runner\Extension\Extension
         Runner\Extension\Facade $facade,
         Runner\Extension\ParameterCollection $parameters,
     ): void {
+        if ($configuration->noOutput()) {
+            return;
+        }
+
         $maximumCount = MaximumCount::fromInt(10);
 
         if ($parameters->has('maximum-count')) {

--- a/test/EndToEnd/NoOutput/SleeperTest.php
+++ b/test/EndToEnd/NoOutput/SleeperTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\NoOutput;
+
+use Ergebnis\PHPUnit\SlowTestDetector\Test;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture\Sleeper
+ */
+final class SleeperTest extends Framework\TestCase
+{
+    use Test\Util\Helper;
+
+    public function testSleeperDoesNotSleepAtAll(): void
+    {
+        $milliseconds = 0;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    public function testSleeperSleepsJustBelowDefaultMaximumDuration(): void
+    {
+        $milliseconds = 400;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    public function testSleeperSleepsJustAboveDefaultMaximumDuration(): void
+    {
+        $milliseconds = 600;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    /**
+     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     */
+    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    {
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    /**
+     * @return \Generator<int, array{0: int}>
+     */
+    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): \Generator
+    {
+        $values = \range(
+            700,
+            1600,
+            100,
+        );
+
+        foreach ($values as $value) {
+            yield $value => [
+                $value,
+            ];
+        }
+    }
+}

--- a/test/EndToEnd/NoOutput/phpunit.xml
+++ b/test/EndToEnd/NoOutput/phpunit.xml
@@ -1,0 +1,32 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="random"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+    </extensions>
+    <testsuites>
+        <testsuite name="unit">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/NoOutput/test.phpt
+++ b/test/EndToEnd/NoOutput/test.phpt
@@ -1,0 +1,18 @@
+--TEST--
+With default configuration of extension
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Default/phpunit.xml';
+$_SERVER['argv'][] = '--no-output';
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--


### PR DESCRIPTION
This pull request

- [x] stops registering the  extension when running `phpunit` with the `--no-output` option