### PR TITLE
Fix: Rename `MaximumCount` to `Count`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.3.2...main`][2.3.2...main].
 
 - Extracted `Duration` ([#351]), by [@localheinz]
 - Merged `MaximumDuration` into `Duration` ([#352]), by [@localheinz]
+- Renamed `MaximumCount` to `Count` ([#353]), by [@localheinz]
 
 ### Fixed
 
@@ -176,5 +177,6 @@ For a full diff see [`7afa59c...1.0.0`][7afa59c...1.0.0].
 [#350]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/350
 [#351]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/351
 [#352]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/352
+[#353]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/353
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Count.php
+++ b/src/Count.php
@@ -16,19 +16,19 @@ namespace Ergebnis\PHPUnit\SlowTestDetector;
 /**
  * @internal
  */
-final class MaximumCount
+final class Count
 {
     private function __construct(private readonly int $value)
     {
     }
 
     /**
-     * @throws Exception\InvalidMaximumCount
+     * @throws Exception\InvalidCount
      */
     public static function fromInt(int $value): self
     {
         if (0 >= $value) {
-            throw Exception\InvalidMaximumCount::notGreaterThanZero($value);
+            throw Exception\InvalidCount::notGreaterThanZero($value);
         }
 
         return new self($value);

--- a/src/Exception/InvalidCount.php
+++ b/src/Exception/InvalidCount.php
@@ -16,7 +16,7 @@ namespace Ergebnis\PHPUnit\SlowTestDetector\Exception;
 /**
  * @internal
  */
-final class InvalidMaximumCount extends \InvalidArgumentException
+final class InvalidCount extends \InvalidArgumentException
 {
     public static function notGreaterThanZero(int $value): self
     {

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -27,10 +27,10 @@ final class Extension implements Runner\Extension\Extension
             return;
         }
 
-        $maximumCount = MaximumCount::fromInt(10);
+        $maximumCount = Count::fromInt(10);
 
         if ($parameters->has('maximum-count')) {
-            $maximumCount = MaximumCount::fromInt((int) $parameters->get('maximum-count'));
+            $maximumCount = Count::fromInt((int) $parameters->get('maximum-count'));
         }
 
         $maximumDuration = Duration::fromMilliseconds(500);

--- a/src/Reporter/DefaultReporter.php
+++ b/src/Reporter/DefaultReporter.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Ergebnis\PHPUnit\SlowTestDetector\Reporter;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Comparator;
+use Ergebnis\PHPUnit\SlowTestDetector\Count;
 use Ergebnis\PHPUnit\SlowTestDetector\Duration;
 use Ergebnis\PHPUnit\SlowTestDetector\Formatter;
-use Ergebnis\PHPUnit\SlowTestDetector\MaximumCount;
 use Ergebnis\PHPUnit\SlowTestDetector\SlowTest;
 
 /**
@@ -29,7 +29,7 @@ final class DefaultReporter implements Reporter
     public function __construct(
         private readonly Formatter\DurationFormatter $durationFormatter,
         private readonly Duration $maximumDuration,
-        private readonly MaximumCount $maximumCount,
+        private readonly Count $maximumCount,
     ) {
         $this->durationComparator = new Comparator\DurationComparator();
     }

--- a/test/Unit/CountTest.php
+++ b/test/Unit/CountTest.php
@@ -14,28 +14,28 @@ declare(strict_types=1);
 namespace Ergebnis\PHPUnit\SlowTestDetector\Test\Unit;
 
 use Ergebnis\DataProvider;
+use Ergebnis\PHPUnit\SlowTestDetector\Count;
 use Ergebnis\PHPUnit\SlowTestDetector\Exception;
-use Ergebnis\PHPUnit\SlowTestDetector\MaximumCount;
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversClass(MaximumCount::class)]
-#[Framework\Attributes\UsesClass(Exception\InvalidMaximumCount::class)]
-final class MaximumCountTest extends Framework\TestCase
+#[Framework\Attributes\CoversClass(Count::class)]
+#[Framework\Attributes\UsesClass(Exception\InvalidCount::class)]
+final class CountTest extends Framework\TestCase
 {
     #[Framework\Attributes\DataProviderExternal(DataProvider\IntProvider::class, 'lessThanZero')]
     #[Framework\Attributes\DataProviderExternal(DataProvider\IntProvider::class, 'zero')]
     public function testFromIntRejectsInvalidValue(int $value): void
     {
-        $this->expectException(Exception\InvalidMaximumCount::class);
+        $this->expectException(Exception\InvalidCount::class);
 
-        MaximumCount::fromInt($value);
+        Count::fromInt($value);
     }
 
     #[Framework\Attributes\DataProviderExternal(DataProvider\IntProvider::class, 'greaterThanZero')]
-    public function testFromSecondsReturnsMaximumCount(int $value): void
+    public function testFromIntReturnsCount(int $value): void
     {
-        $maximumCount = MaximumCount::fromInt($value);
+        $count = Count::fromInt($value);
 
-        self::assertSame($value, $maximumCount->toInt());
+        self::assertSame($value, $count->toInt());
     }
 }

--- a/test/Unit/Exception/InvalidCountTest.php
+++ b/test/Unit/Exception/InvalidCountTest.php
@@ -17,8 +17,8 @@ use Ergebnis\PHPUnit\SlowTestDetector\Exception;
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversClass(Exception\InvalidMaximumCount::class)]
-final class InvalidMaximumCountTest extends Framework\TestCase
+#[Framework\Attributes\CoversClass(Exception\InvalidCount::class)]
+final class InvalidCountTest extends Framework\TestCase
 {
     use Test\Util\Helper;
 
@@ -26,7 +26,7 @@ final class InvalidMaximumCountTest extends Framework\TestCase
     {
         $value = self::faker()->numberBetween();
 
-        $exception = Exception\InvalidMaximumCount::notGreaterThanZero($value);
+        $exception = Exception\InvalidCount::notGreaterThanZero($value);
 
         $message = \sprintf(
             'Value should be greater than 0, but %d is not.',


### PR DESCRIPTION
This pull request

- [x] renames `MaximumCount` to `Count`

Related to #291.