### PR TITLE
Enhancement: Sleep during `setUpBeforeClass()`, `setUp()`, `tearDown()`, and `tearDownAfterClass()`

### DIFF
--- a/test/EndToEnd/Version10/DefaultConfiguration/SleeperTest.php
+++ b/test/EndToEnd/Version10/DefaultConfiguration/SleeperTest.php
@@ -20,6 +20,26 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
+    protected function setUp(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
+    protected function tearDown(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
     public function testSleeperSleepsShorterThanDefaultMaximumDuration(): void
     {
         $milliseconds = 50;

--- a/test/EndToEnd/Version8/DefaultConfiguration/SleeperTest.php
+++ b/test/EndToEnd/Version8/DefaultConfiguration/SleeperTest.php
@@ -21,6 +21,26 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
+    protected function setUp(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
+    protected function tearDown(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
     public function testSleeperSleepsShorterThanDefaultMaximumDuration(): void
     {
         $milliseconds = 50;

--- a/test/EndToEnd/Version8/DefaultConfiguration/test.phpt
+++ b/test/EndToEnd/Version8/DefaultConfiguration/test.phpt
@@ -23,16 +23,16 @@ Random %seed:   %s
 
 Detected 11 tests that took longer than expected.
 
- 1. 1.1%s (1.000) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidSlowThresholdAndMaximumDurationAnnotation
- 2. 1.0%s (1.000) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidMaximumDurationAndSlowThresholdAnnotation
- 3. 1.0%s (0.900) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWithValidSlowThresholdAnnotation
- 4. 0.9%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithInvalidSlowThresholdAnnotation
- 5. 0.9%s (0.800) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidMaximumDurationAnnotation
- 6. 0.8%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithInvalidMaximumDurationAnnotation
- 7. 0.8%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithUselessDocBlock
- 8. 0.7%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDuration
- 9. 0.6%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (600)
-10. 0.5%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (550)
+ 1. 1.2%s (1.000) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidSlowThresholdAndMaximumDurationAnnotation
+ 2. 1.1%s (1.000) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidMaximumDurationAndSlowThresholdAnnotation
+ 3. 1.1%s (0.900) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWithValidSlowThresholdAnnotation
+ 4. 1.0%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithInvalidSlowThresholdAnnotation
+ 5. 1.0%s (0.800) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidMaximumDurationAnnotation
+ 6. 0.9%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithInvalidMaximumDurationAnnotation
+ 7. 0.9%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithUselessDocBlock
+ 8. 0.8%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDuration
+ 9. 0.7%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (600)
+10. 0.6%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version8\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (550)
 
 There is 1 additional slow test that is not listed here.
 

--- a/test/EndToEnd/Version9/DefaultConfiguration/SleeperTest.php
+++ b/test/EndToEnd/Version9/DefaultConfiguration/SleeperTest.php
@@ -21,6 +21,26 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
+    protected function setUp(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
+    protected function tearDown(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+    }
+
     public function testSleeperSleepsShorterThanDefaultMaximumDuration(): void
     {
         $milliseconds = 50;

--- a/test/EndToEnd/Version9/DefaultConfiguration/test.phpt
+++ b/test/EndToEnd/Version9/DefaultConfiguration/test.phpt
@@ -23,16 +23,16 @@ Random %seed:   %s
 
 Detected 11 tests that took longer than expected.
 
- 1. 1.1%s (1.000) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidSlowThresholdAndMaximumDurationAnnotation
- 2. 1.0%s (1.000) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidMaximumDurationAndSlowThresholdAnnotation
- 3. 1.0%s (0.900) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWithValidSlowThresholdAnnotation
- 4. 0.9%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithInvalidSlowThresholdAnnotation
- 5. 0.9%s (0.800) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidMaximumDurationAnnotation
- 6. 0.8%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithInvalidMaximumDurationAnnotation
- 7. 0.8%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithUselessDocBlock
- 8. 0.7%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDuration
- 9. 0.6%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (600)
-10. 0.5%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (550)
+ 1. 1.2%s (1.000) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidSlowThresholdAndMaximumDurationAnnotation
+ 2. 1.1%s (1.000) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidMaximumDurationAndSlowThresholdAnnotation
+ 3. 1.1%s (0.900) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWithValidSlowThresholdAnnotation
+ 4. 1.0%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithInvalidSlowThresholdAnnotation
+ 5. 1.0%s (0.800) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWithValidMaximumDurationAnnotation
+ 6. 0.9%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithInvalidMaximumDurationAnnotation
+ 7. 0.9%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithUselessDocBlock
+ 8. 0.8%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDuration
+ 9. 0.7%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (600)
+10. 0.6%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version9\DefaultConfiguration\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (550)
 
 There is 1 additional slow test that is not listed here.
 


### PR DESCRIPTION
This pull request

- [x] sleeps during `setUpBeforeClass()`, `setUp()`, `tearDown()`, and `tearDownAfterClass()`

Related to #380.