### PR TITLE
Fix: Sleep longer during `setUpBeforeClass()` and `tearDownAfterClass()`

### DIFF
--- a/test/EndToEnd/Version10/DefaultConfiguration/SleeperTest.php
+++ b/test/EndToEnd/Version10/DefaultConfiguration/SleeperTest.php
@@ -22,12 +22,12 @@ final class SleeperTest extends Framework\TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
     public static function tearDownAfterClass(): void
     {
-        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
     protected function setUp(): void

--- a/test/EndToEnd/Version8/DefaultConfiguration/SleeperTest.php
+++ b/test/EndToEnd/Version8/DefaultConfiguration/SleeperTest.php
@@ -23,12 +23,12 @@ final class SleeperTest extends Framework\TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
     public static function tearDownAfterClass(): void
     {
-        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
     protected function setUp(): void

--- a/test/EndToEnd/Version9/DefaultConfiguration/SleeperTest.php
+++ b/test/EndToEnd/Version9/DefaultConfiguration/SleeperTest.php
@@ -23,12 +23,12 @@ final class SleeperTest extends Framework\TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
     public static function tearDownAfterClass(): void
     {
-        Test\Fixture\Sleeper::fromMilliseconds(50)->sleep();
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
     protected function setUp(): void


### PR DESCRIPTION
This pull request

- [x] sleeps longer during `setUpBeforeClass()` and `tearDownAfterClass()`

Follows #397.
Related to #380.