### PR TITLE
Fix: Run unit tests with `phpunit/phpunit:^8.5.19`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -551,8 +551,8 @@ jobs:
         with:
           dependencies: "${{ matrix.dependencies }}"
 
-      - name: "Run unit tests with phpunit/phpunit:9.0.0"
-        if: "matrix.phpunit-version == '9.0.0'"
+      - name: "Run unit tests with phpunit/phpunit:8.5.19"
+        if: "matrix.phpunit-version == '8.5.19'"
         run: "vendor/bin/phpunit --colors=always --configuration=test/Unit/phpunit.xml"
 
       - name: "Run end-to-end tests with phpunit/phpunit:8.5.19"


### PR DESCRIPTION
This pull request

- [x] runs unit tests on GitHub Actions with `phpunit/phpunit:^8.5.19`