### PR TITLE
Fix: Always unset `platform` configuration

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -541,7 +541,6 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-phpunit-${{ matrix.phpunit-version }}-"
 
       - name: "Remove platform configuration with composer"
-        if: "matrix.dependencies != 'locked'"
         run: "composer config platform.php --ansi --unset"
 
       - name: "Remove incompatible dependencies with composer"


### PR DESCRIPTION
This pull request

- [x] always unsets the `platform` configuration when running tests