### PR TITLE
Fix: Throw `PhaseNotStarted` exception when phase was not started

### DIFF
--- a/src/Exception/PhaseNotStarted.php
+++ b/src/Exception/PhaseNotStarted.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Exception;
+
+use Ergebnis\PHPUnit\SlowTestDetector\PhaseIdentifier;
+
+/**
+ * @internal
+ */
+final class PhaseNotStarted extends \InvalidArgumentException
+{
+    public static function fromPhaseIdentifier(PhaseIdentifier $phaseIdentifier): self
+    {
+        return new self(\sprintf(
+            'Phase identified by "%s" has not been started.',
+            $phaseIdentifier->toString(),
+        ));
+    }
+}

--- a/src/TimeKeeper.php
+++ b/src/TimeKeeper.php
@@ -35,6 +35,9 @@ final class TimeKeeper
         );
     }
 
+    /**
+     * @throws Exception\PhaseNotStarted
+     */
     public function stop(
         PhaseIdentifier $phaseIdentifier,
         Time $stopTime
@@ -42,11 +45,7 @@ final class TimeKeeper
         $key = $phaseIdentifier->toString();
 
         if (!\array_key_exists($key, $this->phaseStarts)) {
-            return Phase::create(
-                $phaseIdentifier,
-                $stopTime,
-                $stopTime,
-            );
+            throw Exception\PhaseNotStarted::fromPhaseIdentifier($phaseIdentifier);
         }
 
         $phaseStart = $this->phaseStarts[$key];

--- a/test/Unit/Exception/PhaseNotStartedTest.php
+++ b/test/Unit/Exception/PhaseNotStartedTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\Unit\Exception;
+
+use Ergebnis\PHPUnit\SlowTestDetector\Exception;
+use Ergebnis\PHPUnit\SlowTestDetector\PhaseIdentifier;
+use Ergebnis\PHPUnit\SlowTestDetector\Test;
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Exception\PhaseNotStarted
+ *
+ * @uses \Ergebnis\PHPUnit\SlowTestDetector\PhaseIdentifier
+ */
+final class PhaseNotStartedTest extends Framework\TestCase
+{
+    use Test\Util\Helper;
+
+    public function testFromPhaseIdentifierReturnsException(): void
+    {
+        $phaseIdentifier = PhaseIdentifier::fromString(self::faker()->word());
+
+        $exception = Exception\PhaseNotStarted::fromPhaseIdentifier($phaseIdentifier);
+
+        $message = \sprintf(
+            'Phase identified by "%s" has not been started.',
+            $phaseIdentifier->toString(),
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+}

--- a/test/Unit/TimeKeeperTest.php
+++ b/test/Unit/TimeKeeperTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PHPUnit\SlowTestDetector\Test\Unit;
 
+use Ergebnis\PHPUnit\SlowTestDetector\Exception;
 use Ergebnis\PHPUnit\SlowTestDetector\PhaseIdentifier;
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use Ergebnis\PHPUnit\SlowTestDetector\Time;
@@ -23,6 +24,7 @@ use PHPUnit\Framework;
  * @covers \Ergebnis\PHPUnit\SlowTestDetector\TimeKeeper
  *
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\Duration
+ * @uses \Ergebnis\PHPUnit\SlowTestDetector\Exception\PhaseNotStarted
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\Phase
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\PhaseIdentifier
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\PhaseStart
@@ -32,7 +34,7 @@ final class TimeKeeperTest extends Framework\TestCase
 {
     use Test\Util\Helper;
 
-    public function testStopReturnsPhaseWhenPhaseHasNotBeenStarted(): void
+    public function testStopThrowsPhaseNotStartedExceptionWhenPhaseHasNotBeenStarted(): void
     {
         $faker = self::faker();
 
@@ -44,15 +46,12 @@ final class TimeKeeperTest extends Framework\TestCase
 
         $timeKeeper = new TimeKeeper();
 
-        $phase = $timeKeeper->stop(
+        $this->expectException(Exception\PhaseNotStarted::class);
+
+        $timeKeeper->stop(
             $phaseIdentifier,
             $stopTime,
         );
-
-        self::assertSame($phaseIdentifier, $phase->phaseIdentifier());
-        self::assertSame($stopTime, $phase->startTime());
-        self::assertSame($stopTime, $phase->stopTime());
-        self::assertEquals($stopTime->duration($stopTime), $phase->duration());
     }
 
     public function testStopReturnsPhaseWhenPhaseHasBeenStarted(): void


### PR DESCRIPTION
This pull request

- [x] throws a `PhaseNotStarted` exception when a phase was not started

Follows #420.