### PR TITLE
Fix: Use fixed random order seed for running end-to-end tests

### DIFF
--- a/test/EndToEnd/Version08/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/Defaults/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/Configuration/Defaults/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/MaximumCount/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/Configuration/MaximumCount/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/MaximumDuration/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/Configuration/MaximumDuration/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/Bare/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/Bare/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/Combination/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/Combination/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithAssertPreConditions/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithSetUp/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithSetUp/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithTearDown/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithTearDown/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 /**
  * @see https://github.com/sebastianbergmann/phpunit/blob/8.5.19/src/Framework/TestCase.php#L754C1-L756

--- a/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/Defaults/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/Configuration/Defaults/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/MaximumCount/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/Configuration/MaximumCount/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/MaximumDuration/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/Configuration/MaximumDuration/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/Bare/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/Bare/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/Combination/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/Combination/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithAssertPreConditions/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithSetUp/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithSetUp/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithTearDown/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithTearDown/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 /**
  * @see https://github.com/sebastianbergmann/phpunit/blob/9.0.0/src/Framework/TestCase.php#L706-L708

--- a/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/Defaults/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/Configuration/Defaults/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/MaximumCount/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/Configuration/MaximumCount/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/MaximumDuration/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/Configuration/MaximumDuration/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/Bare/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/Bare/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/Combination/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/Combination/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithAssertPreConditions/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithSetUp/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithSetUp/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithTearDown/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithTearDown/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 /**
  * @see https://github.com/sebastianbergmann/phpunit/blob/10.0.0/src/Framework/TestRunner.php#L288-L290

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 /**
  * @see https://github.com/sebastianbergmann/phpunit/blob/10.0.0/src/Framework/TestRunner.php#L288-L290

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/Defaults/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/Configuration/Defaults/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/MaximumCount/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/Configuration/MaximumCount/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/MaximumDuration/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/Configuration/MaximumDuration/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/Bare/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/Bare/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/Combination/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/Combination/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithAssertPreConditions/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithSetUp/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithSetUp/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithTearDown/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithTearDown/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 /**
  * @see https://github.com/sebastianbergmann/phpunit/blob/main/src/Framework/TestRunner.php#L280-L282

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -8,6 +8,7 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 


### PR DESCRIPTION
This pull request

- [x] uses a fixed random order seed to avoid flaky test runs