### PR TITLE
Fix: Run appropriate tests with `phpunit/phpunit:11.0.x-dev`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -581,4 +581,4 @@ jobs:
 
       - name: "Run end-to-end tests with phpunit/phpunit:11.0.x-dev"
         if: "matrix.phpunit-version == '11.0.x-dev'"
-        run: "vendor/bin/phpunit --colors=always --configuration=test/EndToEnd/Version10/phpunit.xml"
+        run: "vendor/bin/phpunit --colors=always --configuration=test/EndToEnd/Version11/phpunit.xml"


### PR DESCRIPTION
This pull request

- [x] runs the appropriate tests with `phpunit/phpunit:11.0.x-dev`

Follows #423.