### PR TITLE
Fix: Sleep in `assertPreConditions()`

### DIFF
--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -34,6 +34,11 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    protected function assertPreConditions(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
@@ -34,6 +34,11 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    protected function assertPreConditions(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();

--- a/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
@@ -34,6 +34,11 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    protected function assertPreConditions(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();


### PR DESCRIPTION
This pull request

- [x] sleeps in `assertPreConditions()`

Related to #380.