### PR TITLE
Fix: Sleep in `assertPostConditions()`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -85,6 +85,11 @@
       <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/EndToEnd/Version10/TestCase/WithAssertPostConditions/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/EndToEnd/Version10/TestCase/WithAssertPreConditions/SleeperTest.php">
     <PossiblyUnusedMethod>
       <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
@@ -131,6 +136,11 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version11/TestCase/Combination/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/EndToEnd/Version11/TestCase/WithAssertPostConditions/SleeperTest.php">
     <PossiblyUnusedMethod>
       <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
     </PossiblyUnusedMethod>

--- a/test/EndToEnd/Version08/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/Version08/Configuration/Defaults/SleeperTest.php
@@ -23,7 +23,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/Version08/Configuration/MaximumCount/SleeperTest.php
@@ -23,7 +23,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/Version08/Configuration/MaximumDuration/SleeperTest.php
@@ -23,7 +23,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/Bare/SleeperTest.php
@@ -23,7 +23,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/Combination/SleeperTest.php
@@ -53,7 +53,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/Combination/SleeperTest.php
@@ -41,6 +41,11 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    protected function assertPostConditions(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();

--- a/test/EndToEnd/Version08/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/Combination/test.phpt
@@ -1,5 +1,5 @@
 --TEST--
-With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), and tearDown() methods
+With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), assertPostConditions(), and tearDown() methods
 --FILE--
 <?php
 
@@ -24,9 +24,9 @@ Random %seed:   %s
 
 Detected 3 tests that took longer than expected.
 
-1. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2. 0.5%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
-3. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
+1. 0.7%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
+2. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+3. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -11,40 +11,17 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPostConditions;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
+/**
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture\Sleeper
+ */
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -60,7 +37,9 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    /**
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
+     */
     public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);

--- a/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/phpunit.xml
@@ -1,0 +1,36 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    executionOrder="random"
+    forceCoversAnnotation="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <extensions>
+        <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <arguments>
+                <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
+                </array>
+            </arguments>
+        </extension>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/test.phpt
@@ -1,0 +1,33 @@
+--TEST--
+With a test case that has an assertPostConditions() method
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithAssertPostConditions/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version08/TestCase/WithAssertPostConditions/phpunit.xml
+Random %seed:   %s
+
+...                                                                 3 / 3 (100%)
+
+Detected 3 tests that took longer than expected.
+
+1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
+2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+3. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/WithSetUp/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/WithTearDown/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -54,7 +54,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -53,7 +53,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -67,7 +67,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 50;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -41,6 +41,11 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    protected function assertPostConditions(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -1,5 +1,5 @@
 --TEST--
-With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), tearDown() methods and test methods with @runInSeparateProcess annotation
+With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), assertPostConditions(), tearDown() methods and test methods with @runInSeparateProcess annotation
 --FILE--
 <?php
 
@@ -29,10 +29,10 @@ Random %seed:   %s
 
 Detected 4 tests that took longer than expected.
 
-1. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
-2. 0.5%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
-3. 0.5%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
-4. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
+1. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+2. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+3. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
+4. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -60,7 +60,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/Version09/Configuration/Defaults/SleeperTest.php
@@ -23,7 +23,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/Version09/Configuration/MaximumCount/SleeperTest.php
@@ -23,7 +23,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/Version09/Configuration/MaximumDuration/SleeperTest.php
@@ -23,7 +23,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/Bare/SleeperTest.php
@@ -23,7 +23,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/Combination/SleeperTest.php
@@ -53,7 +53,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/Combination/SleeperTest.php
@@ -41,6 +41,11 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    protected function assertPostConditions(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();

--- a/test/EndToEnd/Version09/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/Combination/test.phpt
@@ -1,5 +1,5 @@
 --TEST--
-With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), and tearDown() methods
+With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), assertPostConditions(), and tearDown() methods
 --FILE--
 <?php
 
@@ -24,9 +24,9 @@ Random %seed:   %s
 
 Detected 3 tests that took longer than expected.
 
-1. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2. 0.5%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
-3. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
+1. 0.7%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
+2. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+3. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -11,40 +11,17 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPostConditions;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
+/**
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture\Sleeper
+ */
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -60,7 +37,9 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    /**
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
+     */
     public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);

--- a/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/phpunit.xml
@@ -1,0 +1,36 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    executionOrder="random"
+    forceCoversAnnotation="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <extensions>
+        <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <arguments>
+                <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
+                </array>
+            </arguments>
+        </extension>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/test.phpt
@@ -1,0 +1,33 @@
+--TEST--
+With a test case that has an assertPostConditions() method
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithAssertPostConditions/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version09/TestCase/WithAssertPostConditions/phpunit.xml
+Random %seed:   %s
+
+...                                                                 3 / 3 (100%)
+
+Detected 3 tests that took longer than expected.
+
+1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
+2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+3. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/WithSetUp/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/WithTearDown/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -54,7 +54,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -53,7 +53,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -67,7 +67,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 50;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -41,6 +41,11 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    protected function assertPostConditions(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -1,5 +1,5 @@
 --TEST--
-With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), tearDown() methods and test methods with @runInSeparateProcess annotation
+With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), assertPostConditions(), tearDown() methods and test methods with @runInSeparateProcess annotation
 --FILE--
 <?php
 
@@ -29,10 +29,10 @@ Random %seed:   %s
 
 Detected 4 tests that took longer than expected.
 
-1. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
-2. 0.5%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
-3. 0.5%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
-4. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
+1. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+2. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+3. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
+4. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/SleeperTest.php
@@ -28,7 +28,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -60,7 +60,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/Version10/Configuration/Defaults/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/Version10/Configuration/MaximumCount/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/Version10/Configuration/MaximumDuration/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/Bare/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/Combination/SleeperTest.php
@@ -51,7 +51,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/Combination/test.phpt
@@ -1,5 +1,5 @@
 --TEST--
-With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), and tearDown() methods
+With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), assertPostConditions(), and tearDown() methods
 --FILE--
 <?php
 
@@ -24,10 +24,11 @@ Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 3 tests that took longer than expected.
 
-1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
-2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
+2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+3. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPostConditions;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
@@ -19,32 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }

--- a/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.xml
@@ -1,0 +1,34 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="random"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/test.phpt
@@ -1,0 +1,35 @@
+--TEST--
+With a test case that has an assertPostConditions() method
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.xml
+Random %seed:   %s
+
+...                                                                 3 / 3 (100%)
+
+Detected 3 tests that took longer than expected.
+
+1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
+2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+3. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithSetUp/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithTearDown/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
@@ -24,7 +24,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -52,7 +52,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/SleeperTest.php
@@ -23,7 +23,7 @@ final class SleeperTest extends Framework\TestCase
     #[Attribute\MaximumDuration(200)]
     public function testSleeperSleepsShorterThanMaximumDurationFromAttributeWhenTestMethodHasValidMaximumDurationAttribute(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -39,6 +39,11 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    protected function assertPostConditions(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -51,7 +51,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -65,7 +65,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 50;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -1,5 +1,5 @@
 --TEST--
-With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), tearDown() methods and test methods with @runInSeparateProcess annotation
+With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), assertPostConditions(), tearDown() methods and test methods with @runInSeparateProcess annotation
 --FILE--
 <?php
 
@@ -29,10 +29,12 @@ Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 4 tests that took longer than expected.
 
-1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
-2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
+1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
+3. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+4. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
@@ -51,7 +51,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -63,7 +63,7 @@ final class SleeperTest extends Framework\TestCase
     #[Framework\Attributes\RunInSeparateProcess]
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 50;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
@@ -39,6 +39,11 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    protected function assertPostConditions(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
@@ -1,5 +1,5 @@
 --TEST--
-With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), tearDown() methods and test methods with RunInSeparateProcess attribute
+With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), assertPostConditions(), tearDown() methods and test methods with RunInSeparateProcess attribute
 --FILE--
 <?php
 
@@ -29,10 +29,12 @@ Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 4 tests that took longer than expected.
 
-1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute
-2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
+1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute
+2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
+3. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute
+4. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -58,7 +58,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/Version11/Configuration/Defaults/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/Version11/Configuration/MaximumCount/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/Version11/Configuration/MaximumDuration/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/Bare/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/Combination/SleeperTest.php
@@ -51,7 +51,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/Combination/SleeperTest.php
@@ -39,6 +39,11 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    protected function assertPostConditions(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();

--- a/test/EndToEnd/Version11/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/Combination/test.phpt
@@ -1,5 +1,5 @@
 --TEST--
-With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), and tearDown() methods
+With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), assertPostConditions(), and tearDown() methods
 --FILE--
 <?php
 
@@ -24,10 +24,11 @@ Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 3 tests that took longer than expected.
 
-1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
-2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
+2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+3. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPostConditions;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
@@ -19,32 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }

--- a/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.xml
@@ -1,0 +1,34 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="random"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/test.phpt
@@ -1,0 +1,35 @@
+--TEST--
+With a test case that has an assertPostConditions() method
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.xml';
+$_SERVER['argv'][] = '--random-order-seed=1234567890';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.xml
+Random %seed:   %s
+
+...                                                                 3 / 3 (100%)
+
+Detected 3 tests that took longer than expected.
+
+1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
+2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+3. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/WithSetUp/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/WithTearDown/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
@@ -24,7 +24,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -52,7 +52,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/SleeperTest.php
@@ -23,7 +23,7 @@ final class SleeperTest extends Framework\TestCase
     #[Attribute\MaximumDuration(200)]
     public function testSleeperSleepsShorterThanMaximumDurationFromAttributeWhenTestMethodHasValidMaximumDurationAttribute(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
@@ -51,7 +51,7 @@ final class SleeperTest extends Framework\TestCase
 
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 50;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -63,7 +63,7 @@ final class SleeperTest extends Framework\TestCase
     #[Framework\Attributes\RunInSeparateProcess]
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
@@ -39,6 +39,11 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    protected function assertPostConditions(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     protected function tearDown(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();

--- a/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
@@ -1,5 +1,5 @@
 --TEST--
-With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), tearDown() methods and test methods with RunInSeparateProcess attribute
+With a test case that has setUpBeforeClass(), tearDownAfterClass(), setUp(), assertPreConditions(), assertPostConditions(), tearDown() methods and test methods with RunInSeparateProcess attribute
 --FILE--
 <?php
 
@@ -29,10 +29,12 @@ Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 4 tests that took longer than expected.
 
-1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute
-2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
+1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute
+2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
+3. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
+4. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/SleeperTest.php
@@ -26,7 +26,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -58,7 +58,7 @@ final class SleeperTest extends Framework\TestCase
      */
     public function testSleeperSleepsShorterThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation(): void
     {
-        $milliseconds = 1;
+        $milliseconds = 10;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 


### PR DESCRIPTION
This pull request

- [x] sleeps in `assertPostConditions()`

Related to #380.