### PR TITLE
Fix: Do not run tests in random execution order

### DIFF
--- a/test/EndToEnd/Version08/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/Version08/Configuration/Defaults/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/Defaults/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/Configuration/Defaults/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/Configuration/Defaults/phpunit.xml
-Random %seed:   %s
 
 ............                                                      12 / 12 (100%)
 

--- a/test/EndToEnd/Version08/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/Version08/Configuration/MaximumCount/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/MaximumCount/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/Configuration/MaximumCount/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/Configuration/MaximumCount/phpunit.xml
-Random %seed:   %s
 
 ......                                                              6 / 6 (100%)
 

--- a/test/EndToEnd/Version08/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/Version08/Configuration/MaximumDuration/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/MaximumDuration/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/Configuration/MaximumDuration/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/Configuration/MaximumDuration/phpunit.xml
-Random %seed:   %s
 
 ............                                                      12 / 12 (100%)
 

--- a/test/EndToEnd/Version08/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/Bare/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/Bare/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/Bare/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestCase/Bare/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version08/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/Combination/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/Combination/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/Combination/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestCase/Combination/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version08/TestCase/WithAfterAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithAfterAnnotation/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAfterAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithTearDown/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestCase/WithTearDown/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithAssertPostConditions/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestCase/WithAssertPostConditions/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithAssertPreConditions/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestCase/WithAssertPreConditions/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version08/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithDataProvider/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithDataProvider/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithDataProvider/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestCase/WithDataProvider/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version08/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithSetUp/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithSetUp/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithSetUp/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestCase/WithSetUp/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version08/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithTearDown/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithTearDown/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithTearDown/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestCase/WithTearDown/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestCase/WithTearDownAfterClass/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
-Random %seed:   %s
 
 ..                                                                  2 / 2 (100%)
 

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 /**
  * @see https://github.com/sebastianbergmann/phpunit/blob/8.5.19/src/Framework/TestCase.php#L754C1-L756
@@ -23,7 +22,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
-Random %seed:   %s
 
 ..                                                                  2 / 2 (100%)
 

--- a/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version08/phpunit.xml
+++ b/test/EndToEnd/Version08/phpunit.xml
@@ -10,7 +10,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/Version09/Configuration/Defaults/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/Defaults/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/Configuration/Defaults/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/Configuration/Defaults/phpunit.xml
-Random %seed:   %s
 
 ............                                                      12 / 12 (100%)
 

--- a/test/EndToEnd/Version09/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/Version09/Configuration/MaximumCount/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/MaximumCount/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/Configuration/MaximumCount/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/Configuration/MaximumCount/phpunit.xml
-Random %seed:   %s
 
 ......                                                              6 / 6 (100%)
 

--- a/test/EndToEnd/Version09/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/Version09/Configuration/MaximumDuration/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/MaximumDuration/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/Configuration/MaximumDuration/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/Configuration/MaximumDuration/phpunit.xml
-Random %seed:   %s
 
 ............                                                      12 / 12 (100%)
 

--- a/test/EndToEnd/Version09/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/Bare/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/Bare/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/Bare/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestCase/Bare/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version09/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/Combination/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/Combination/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/Combination/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestCase/Combination/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version09/TestCase/WithAfterAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithAfterAnnotation/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAfterAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithAfterAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestCase/WithAfterAnnotation/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithAssertPostConditions/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestCase/WithAssertPostConditions/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithAssertPreConditions/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestCase/WithAssertPreConditions/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version09/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithDataProvider/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithDataProvider/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithDataProvider/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestCase/WithDataProvider/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version09/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithSetUp/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithSetUp/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithSetUp/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestCase/WithSetUp/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version09/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithTearDown/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithTearDown/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithTearDown/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestCase/WithTearDown/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestCase/WithTearDownAfterClass/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
-Random %seed:   %s
 
 ..                                                                  2 / 2 (100%)
 

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 /**
  * @see https://github.com/sebastianbergmann/phpunit/blob/9.0.0/src/Framework/TestCase.php#L706-L708
@@ -23,7 +22,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
-Random %seed:   %s
 
 ..                                                                  2 / 2 (100%)
 

--- a/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -9,7 +9,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -18,7 +17,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version09/phpunit.xml
+++ b/test/EndToEnd/Version09/phpunit.xml
@@ -10,7 +10,7 @@
     cacheResult="false"
     colors="true"
     columns="max"
-    executionOrder="random"
+    executionOrder="default"
     forceCoversAnnotation="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version10/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/Version10/Configuration/Defaults/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     requireCoverageMetadata="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version10/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/Defaults/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/Configuration/Defaults/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/Configuration/Defaults/phpunit.xml
-Random %seed:   %s
 
 ............                                                      12 / 12 (100%)
 

--- a/test/EndToEnd/Version10/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/Version10/Configuration/MaximumCount/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     requireCoverageMetadata="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version10/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/MaximumCount/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/Configuration/MaximumCount/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/Configuration/MaximumCount/phpunit.xml
-Random %seed:   %s
 
 ......                                                              6 / 6 (100%)
 

--- a/test/EndToEnd/Version10/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/Version10/Configuration/MaximumDuration/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     requireCoverageMetadata="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version10/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/MaximumDuration/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/Configuration/MaximumDuration/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/Configuration/MaximumDuration/phpunit.xml
-Random %seed:   %s
 
 ............                                                      12 / 12 (100%)
 

--- a/test/EndToEnd/Version10/Option/NoOutput/phpunit.xml
+++ b/test/EndToEnd/Version10/Option/NoOutput/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/Bare/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/Bare/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/Bare/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestCase/Bare/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version10/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/Combination/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/Combination/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/Combination/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestCase/Combination/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version10/TestCase/WithAfterAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithAfterAnnotation/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAfterAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithAfterAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestCase/WithAfterAnnotation/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version10/TestCase/WithAfterAttribute/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithAfterAttribute/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/WithAfterAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAfterAttribute/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithAfterAttribute/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestCase/WithAfterAttribute/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithAssertPreConditions/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestCase/WithAssertPreConditions/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version10/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithDataProvider/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithDataProvider/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithDataProvider/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestCase/WithDataProvider/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version10/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithSetUp/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithSetUp/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithSetUp/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestCase/WithSetUp/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version10/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithTearDown/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithTearDown/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithTearDown/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestCase/WithTearDown/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestCase/WithTearDownAfterClass/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
-Random %seed:   %s
 
 ..                                                                  2 / 2 (100%)
 

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/phpunit.xml
-Random %seed:   %s
 
 ..                                                                  2 / 2 (100%)
 

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 /**
  * @see https://github.com/sebastianbergmann/phpunit/blob/10.0.0/src/Framework/TestRunner.php#L288-L290
@@ -25,7 +24,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 /**
  * @see https://github.com/sebastianbergmann/phpunit/blob/10.0.0/src/Framework/TestRunner.php#L288-L290
@@ -25,7 +24,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
-Random %seed:   %s
 
 ..                                                                  2 / 2 (100%)
 

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version10/phpunit.xml
+++ b/test/EndToEnd/Version10/phpunit.xml
@@ -16,7 +16,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     requireCoverageMetadata="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version11/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/Version11/Configuration/Defaults/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     requireCoverageMetadata="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version11/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/Defaults/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/Configuration/Defaults/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/Configuration/Defaults/phpunit.xml
-Random %seed:   %s
 
 ............                                                      12 / 12 (100%)
 

--- a/test/EndToEnd/Version11/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/Version11/Configuration/MaximumCount/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     requireCoverageMetadata="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version11/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/MaximumCount/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/Configuration/MaximumCount/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/Configuration/MaximumCount/phpunit.xml
-Random %seed:   %s
 
 ......                                                              6 / 6 (100%)
 

--- a/test/EndToEnd/Version11/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/Version11/Configuration/MaximumDuration/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     requireCoverageMetadata="true"
     stopOnError="false"
     stopOnFailure="false"

--- a/test/EndToEnd/Version11/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/MaximumDuration/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/Configuration/MaximumDuration/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/Configuration/MaximumDuration/phpunit.xml
-Random %seed:   %s
 
 ............                                                      12 / 12 (100%)
 

--- a/test/EndToEnd/Version11/Option/NoOutput/phpunit.xml
+++ b/test/EndToEnd/Version11/Option/NoOutput/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/Bare/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/Bare/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/Bare/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestCase/Bare/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version11/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/Combination/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/Combination/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/Combination/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestCase/Combination/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version11/TestCase/WithAfterAttribute/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithAfterAttribute/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestCase/WithAfterAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAfterAttribute/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithAfterAttribute/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestCase/WithAfterAttribute/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithAssertPreConditions/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestCase/WithAssertPreConditions/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version11/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithDataProvider/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithDataProvider/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithDataProvider/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestCase/WithDataProvider/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version11/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithSetUp/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithSetUp/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithSetUp/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestCase/WithSetUp/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version11/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithTearDown/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithTearDown/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithTearDown/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestCase/WithTearDown/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestCase/WithTearDownAfterClass/phpunit.xml
-Random %seed:   %s
 
 ...                                                                 3 / 3 (100%)
 

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
-Random %seed:   %s
 
 ..                                                                  2 / 2 (100%)
 

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/phpunit.xml
-Random %seed:   %s
 
 ..                                                                  2 / 2 (100%)
 

--- a/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 /**
  * @see https://github.com/sebastianbergmann/phpunit/blob/main/src/Framework/TestRunner.php#L280-L282
@@ -25,7 +24,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
-Random %seed:   %s
 
 ..                                                                  2 / 2 (100%)
 

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -15,7 +15,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -8,7 +8,6 @@ declare(strict_types=1);
 use PHPUnit\TextUI;
 
 $_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/phpunit.xml';
-$_SERVER['argv'][] = '--random-order-seed=1234567890';
 
 require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
@@ -20,7 +19,6 @@ PHPUnit %s
 
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
-Random %seed:   %s
 
 ....                                                                4 / 4 (100%)
 

--- a/test/EndToEnd/Version11/phpunit.xml
+++ b/test/EndToEnd/Version11/phpunit.xml
@@ -16,7 +16,7 @@
     displayDetailsOnTestsThatTriggerErrors="true"
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
-    executionOrder="random"
+    executionOrder="default"
     requireCoverageMetadata="true"
     stopOnError="false"
     stopOnFailure="false"


### PR DESCRIPTION
This pull request

- [x] stops running tests in random execution order