### PR TITLE
Fix: Sleep in method with `@before` annotation or `Before` attribute

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -64,6 +64,7 @@
     <PossiblyUnusedMethod>
       <code>sleepWithAfterAnnotation</code>
       <code>sleepWithAfterClassAnnotation</code>
+      <code>sleepWithBeforeAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version08/TestCase/WithAfterAnnotation/SleeperTest.php">
@@ -76,16 +77,23 @@
       <code>sleepWithAfterClassAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>sleepWithBeforeAnnotation</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php">
     <PossiblyUnusedMethod>
       <code>sleepWithAfterAnnotation</code>
       <code>sleepWithAfterClassAnnotation</code>
+      <code>sleepWithBeforeAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version09/TestCase/Combination/SleeperTest.php">
     <PossiblyUnusedMethod>
       <code>sleepWithAfterAnnotation</code>
       <code>sleepWithAfterClassAnnotation</code>
+      <code>sleepWithBeforeAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version09/TestCase/WithAfterAnnotation/SleeperTest.php">
@@ -98,10 +106,16 @@
       <code>sleepWithAfterClassAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>sleepWithBeforeAnnotation</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php">
     <PossiblyUnusedMethod>
       <code>sleepWithAfterAnnotation</code>
       <code>sleepWithAfterClassAnnotation</code>
+      <code>sleepWithBeforeAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version10/Configuration/Defaults/SleeperTest.php">
@@ -131,6 +145,8 @@
       <code>sleepWithAfterAttribute</code>
       <code>sleepWithAfterClassAnnotation</code>
       <code>sleepWithAfterClassAttribute</code>
+      <code>sleepWithBeforeAnnotation</code>
+      <code>sleepWithBeforeAttribute</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version10/TestCase/WithAfterAnnotation/SleeperTest.php">
@@ -167,6 +183,18 @@
       <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
+      <code>sleepWithBeforeAnnotation</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/EndToEnd/Version10/TestCase/WithBeforeAttribute/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
+      <code>sleepWithBeforeAttribute</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/EndToEnd/Version10/TestCase/WithDataProvider/SleeperTest.php">
     <PossiblyUnusedMethod>
       <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
@@ -198,6 +226,8 @@
       <code>sleepWithAfterAttribute</code>
       <code>sleepWithAfterClassAnnotation</code>
       <code>sleepWithAfterClassAttribute</code>
+      <code>sleepWithBeforeAnnotation</code>
+      <code>sleepWithBeforeAttribute</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php">
@@ -206,6 +236,8 @@
       <code>sleepWithAfterAttribute</code>
       <code>sleepWithAfterClassAnnotation</code>
       <code>sleepWithAfterClassAttribute</code>
+      <code>sleepWithBeforeAnnotation</code>
+      <code>sleepWithBeforeAttribute</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version11/Configuration/Defaults/SleeperTest.php">
@@ -233,6 +265,7 @@
       <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
       <code>sleepWithAfterAttribute</code>
       <code>sleepWithAfterClassAttribute</code>
+      <code>sleepWithBeforeAttribute</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version11/TestCase/WithAfterAttribute/SleeperTest.php">
@@ -255,6 +288,12 @@
   <file src="test/EndToEnd/Version11/TestCase/WithAssertPreConditions/SleeperTest.php">
     <PossiblyUnusedMethod>
       <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/EndToEnd/Version11/TestCase/WithBeforeAttribute/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
+      <code>sleepWithBeforeAttribute</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version11/TestCase/WithDataProvider/SleeperTest.php">

--- a/test/EndToEnd/Version08/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/Combination/test.phpt
@@ -22,9 +22,9 @@ Configuration: %s/EndToEnd/Version08/TestCase/Combination/phpunit.xml
 
 Detected 3 tests that took longer than expected.
 
-1. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2. 0.7%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
-3. 0.5%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
+1. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
+2. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+3. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/SleeperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeAnnotation;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
@@ -21,56 +21,10 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     /**
      * @before
      */
     public function sleepWithBeforeAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @after
-     */
-    public function sleepWithAfterAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @afterClass
-     */
-    public static function sleepWithAfterClassAnnotation(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -110,8 +64,6 @@ final class SleeperTest extends Framework\TestCase
         );
 
         foreach ($values as $value) {
-            Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-
             yield $value => [
                 $value,
             ];

--- a/test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/phpunit.xml
@@ -1,0 +1,36 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    executionOrder="default"
+    forceCoversAnnotation="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <extensions>
+        <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <arguments>
+                <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
+                </array>
+            </arguments>
+        </extension>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/test.phpt
@@ -1,0 +1,31 @@
+--TEST--
+With a test case that sleeps in a method with @before annotation
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version08/TestCase/WithBeforeAnnotation/phpunit.xml
+
+...                                                                 3 / 3 (100%)
+
+Detected 3 tests that took longer than expected.
+
+1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
+2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+3. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -52,6 +52,14 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
+     * @before
+     */
+    public function sleepWithBeforeAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    /**
      * @after
      */
     public function sleepWithAfterAnnotation(): void

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -27,10 +27,10 @@ Configuration: %s/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotati
 
 Detected 4 tests that took longer than expected.
 
-1. 1.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
-2. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
-3. 0.7%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
-4. 0.5%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
+1. 1.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+2. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+3. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
+4. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version09/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/Combination/SleeperTest.php
@@ -52,6 +52,14 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
+     * @before
+     */
+    public function sleepWithBeforeAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    /**
      * @after
      */
     public function sleepWithAfterAnnotation(): void

--- a/test/EndToEnd/Version09/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/Combination/test.phpt
@@ -22,9 +22,9 @@ Configuration: %s/EndToEnd/Version09/TestCase/Combination/phpunit.xml
 
 Detected 3 tests that took longer than expected.
 
-1. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2. 0.7%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
-3. 0.5%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
+1. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
+2. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+3. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/SleeperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeAnnotation;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
@@ -21,56 +21,10 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     /**
      * @before
      */
     public function sleepWithBeforeAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @after
-     */
-    public function sleepWithAfterAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @afterClass
-     */
-    public static function sleepWithAfterClassAnnotation(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -110,8 +64,6 @@ final class SleeperTest extends Framework\TestCase
         );
 
         foreach ($values as $value) {
-            Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-
             yield $value => [
                 $value,
             ];

--- a/test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/phpunit.xml
@@ -1,0 +1,36 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    executionOrder="default"
+    forceCoversAnnotation="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <extensions>
+        <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <arguments>
+                <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
+                </array>
+            </arguments>
+        </extension>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/test.phpt
@@ -1,0 +1,31 @@
+--TEST--
+With a test case that sleeps in a method with @before annotation
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version09/TestCase/WithBeforeAnnotation/phpunit.xml
+
+...                                                                 3 / 3 (100%)
+
+Detected 3 tests that took longer than expected.
+
+1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
+2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+3. 0.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -52,6 +52,14 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
+     * @before
+     */
+    public function sleepWithBeforeAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    /**
      * @after
      */
     public function sleepWithAfterAnnotation(): void

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -27,10 +27,10 @@ Configuration: %s/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotati
 
 Detected 4 tests that took longer than expected.
 
-1. 1.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
-2. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
-3. 0.7%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
-4. 0.5%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
+1. 1.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+2. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+3. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
+4. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
 Time: %s, Memory: %s
 

--- a/test/EndToEnd/Version10/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/Combination/SleeperTest.php
@@ -50,6 +50,20 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
+     * @before
+     */
+    public function sleepWithBeforeAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    #[Framework\Attributes\Before]
+    public function sleepWithBeforeAttribute(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    /**
      * @after
      */
     public function sleepWithAfterAnnotation(): void

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/SleeperTest.php
@@ -11,66 +11,18 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAnnotation;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
 
-/**
- * @covers \Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture\Sleeper
- */
+#[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     /**
      * @before
      */
     public function sleepWithBeforeAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @after
-     */
-    public function sleepWithAfterAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @afterClass
-     */
-    public static function sleepWithAfterClassAnnotation(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -86,9 +38,7 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    /**
-     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
-     */
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
     public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
@@ -110,8 +60,6 @@ final class SleeperTest extends Framework\TestCase
         );
 
         foreach ($values as $value) {
-            Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-
             yield $value => [
                 $value,
             ];

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/phpunit.xml
@@ -1,0 +1,34 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/test.phpt
@@ -1,0 +1,32 @@
+--TEST--
+With a test case that sleeps in a method with @before annotation
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeAnnotation/phpunit.xml
+
+...                                                                 3 / 3 (100%)
+
+Detected 2 tests that took longer than expected.
+
+1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
+2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/SleeperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAttribute;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
@@ -19,50 +19,8 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     #[Framework\Attributes\Before]
     public function sleepWithBeforeAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\After]
-    public function sleepWithAfterAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\AfterClass]
-    public static function sleepWithAfterClassAttribute(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -100,8 +58,6 @@ final class SleeperTest extends Framework\TestCase
         );
 
         foreach ($values as $value) {
-            Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-
             yield $value => [
                 $value,
             ];

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/phpunit.xml
@@ -1,0 +1,34 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/test.phpt
@@ -1,0 +1,32 @@
+--TEST--
+With a test case that sleeps in a method with Before attribute
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithBeforeAttribute/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeAttribute/phpunit.xml
+
+...                                                                 3 / 3 (100%)
+
+Detected 2 tests that took longer than expected.
+
+1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
+2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -50,6 +50,20 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
+     * @before
+     */
+    public function sleepWithBeforeAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    #[Framework\Attributes\Before]
+    public function sleepWithBeforeAttribute(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    /**
      * @after
      */
     public function sleepWithAfterAnnotation(): void

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
@@ -50,6 +50,20 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
+     * @before
+     */
+    public function sleepWithBeforeAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    #[Framework\Attributes\Before]
+    public function sleepWithBeforeAttribute(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    /**
      * @after
      */
     public function sleepWithAfterAnnotation(): void

--- a/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/SleeperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeAttribute;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
@@ -19,50 +19,8 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     #[Framework\Attributes\Before]
     public function sleepWithBeforeAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\After]
-    public function sleepWithAfterAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\AfterClass]
-    public static function sleepWithAfterClassAttribute(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -100,8 +58,6 @@ final class SleeperTest extends Framework\TestCase
         );
 
         foreach ($values as $value) {
-            Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-
             yield $value => [
                 $value,
             ];

--- a/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/phpunit.xml
@@ -1,0 +1,34 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/test.phpt
@@ -1,0 +1,32 @@
+--TEST--
+With a test case that sleeps in a method with Before attribute
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithBeforeAttribute/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version11/TestCase/WithBeforeAttribute/phpunit.xml
+
+...                                                                 3 / 3 (100%)
+
+Detected 2 tests that took longer than expected.
+
+1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
+2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)


### PR DESCRIPTION
This pull request

- [x] sleeps in methods with `@before` annotation or `Before` attribute

Related to #380.