### PR TITLE
Fix: Sleep in method with `@beforeClass` annotation or `BeforeClass` attribute

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -65,6 +65,7 @@
       <code>sleepWithAfterAnnotation</code>
       <code>sleepWithAfterClassAnnotation</code>
       <code>sleepWithBeforeAnnotation</code>
+      <code>sleepWithBeforeClassAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version08/TestCase/WithAfterAnnotation/SleeperTest.php">
@@ -82,11 +83,17 @@
       <code>sleepWithBeforeAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>sleepWithBeforeClassAnnotation</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php">
     <PossiblyUnusedMethod>
       <code>sleepWithAfterAnnotation</code>
       <code>sleepWithAfterClassAnnotation</code>
       <code>sleepWithBeforeAnnotation</code>
+      <code>sleepWithBeforeClassAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version09/TestCase/Combination/SleeperTest.php">
@@ -94,6 +101,7 @@
       <code>sleepWithAfterAnnotation</code>
       <code>sleepWithAfterClassAnnotation</code>
       <code>sleepWithBeforeAnnotation</code>
+      <code>sleepWithBeforeClassAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version09/TestCase/WithAfterAnnotation/SleeperTest.php">
@@ -111,11 +119,17 @@
       <code>sleepWithBeforeAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>sleepWithBeforeClassAnnotation</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php">
     <PossiblyUnusedMethod>
       <code>sleepWithAfterAnnotation</code>
       <code>sleepWithAfterClassAnnotation</code>
       <code>sleepWithBeforeAnnotation</code>
+      <code>sleepWithBeforeClassAnnotation</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version10/Configuration/Defaults/SleeperTest.php">
@@ -147,6 +161,8 @@
       <code>sleepWithAfterClassAttribute</code>
       <code>sleepWithBeforeAnnotation</code>
       <code>sleepWithBeforeAttribute</code>
+      <code>sleepWithBeforeClassAnnotation</code>
+      <code>sleepWithBeforeClassAttribute</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version10/TestCase/WithAfterAnnotation/SleeperTest.php">
@@ -195,6 +211,18 @@
       <code>sleepWithBeforeAttribute</code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
+      <code>sleepWithBeforeClassAnnotation</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
+      <code>sleepWithBeforeClassAttribute</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/EndToEnd/Version10/TestCase/WithDataProvider/SleeperTest.php">
     <PossiblyUnusedMethod>
       <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
@@ -228,6 +256,8 @@
       <code>sleepWithAfterClassAttribute</code>
       <code>sleepWithBeforeAnnotation</code>
       <code>sleepWithBeforeAttribute</code>
+      <code>sleepWithBeforeClassAnnotation</code>
+      <code>sleepWithBeforeClassAttribute</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php">
@@ -238,6 +268,8 @@
       <code>sleepWithAfterClassAttribute</code>
       <code>sleepWithBeforeAnnotation</code>
       <code>sleepWithBeforeAttribute</code>
+      <code>sleepWithBeforeClassAnnotation</code>
+      <code>sleepWithBeforeClassAttribute</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version11/Configuration/Defaults/SleeperTest.php">
@@ -266,6 +298,7 @@
       <code>sleepWithAfterAttribute</code>
       <code>sleepWithAfterClassAttribute</code>
       <code>sleepWithBeforeAttribute</code>
+      <code>sleepWithBeforeClassAttribute</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version11/TestCase/WithAfterAttribute/SleeperTest.php">
@@ -294,6 +327,12 @@
     <PossiblyUnusedMethod>
       <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
       <code>sleepWithBeforeAttribute</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/SleeperTest.php">
+    <PossiblyUnusedMethod>
+      <code>provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration</code>
+      <code>sleepWithBeforeClassAttribute</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EndToEnd/Version11/TestCase/WithDataProvider/SleeperTest.php">
@@ -326,6 +365,7 @@
       <code>sleepWithAfterAttribute</code>
       <code>sleepWithAfterClassAttribute</code>
       <code>sleepWithBeforeAttribute</code>
+      <code>sleepWithBeforeClassAttribute</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/Fixture/Sleeper.php">

--- a/test/EndToEnd/Version08/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/Combination/SleeperTest.php
@@ -60,6 +60,14 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
+     * @beforeClass
+     */
+    public function sleepWithBeforeClassAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    /**
      * @after
      */
     public function sleepWithAfterAnnotation(): void

--- a/test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/SleeperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeClassAnnotation;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
@@ -21,64 +21,10 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @before
-     */
-    public function sleepWithBeforeAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     /**
      * @beforeClass
      */
     public static function sleepWithBeforeClassAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @after
-     */
-    public function sleepWithAfterAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @afterClass
-     */
-    public static function sleepWithAfterClassAnnotation(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -118,8 +64,6 @@ final class SleeperTest extends Framework\TestCase
         );
 
         foreach ($values as $value) {
-            Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-
             yield $value => [
                 $value,
             ];

--- a/test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/phpunit.xml
@@ -1,0 +1,36 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    executionOrder="default"
+    forceCoversAnnotation="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <extensions>
+        <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <arguments>
+                <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
+                </array>
+            </arguments>
+        </extension>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -1,0 +1,30 @@
+--TEST--
+With a test case that sleeps in a method with @beforeClass annotation
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/phpunit.xml
+
+...                                                                 3 / 3 (100%)
+
+Detected 2 tests that took longer than expected.
+
+1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
+2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -60,6 +60,14 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
+     * @beforeClass
+     */
+    public static function sleepWithBeforeClassAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    /**
      * @after
      */
     public function sleepWithAfterAnnotation(): void

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -27,8 +27,8 @@ Configuration: %s/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotati
 
 Detected 4 tests that took longer than expected.
 
-1. 1.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
-2. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+1. 1.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+2. 1.0%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
 3. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
 4. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 

--- a/test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/SleeperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeClassAnnotation;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
@@ -21,64 +21,10 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @before
-     */
-    public function sleepWithBeforeAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     /**
      * @beforeClass
      */
     public static function sleepWithBeforeClassAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @after
-     */
-    public function sleepWithAfterAnnotation(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    /**
-     * @afterClass
-     */
-    public static function sleepWithAfterClassAnnotation(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -118,8 +64,6 @@ final class SleeperTest extends Framework\TestCase
         );
 
         foreach ($values as $value) {
-            Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-
             yield $value => [
                 $value,
             ];

--- a/test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/phpunit.xml
@@ -1,0 +1,36 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    executionOrder="default"
+    forceCoversAnnotation="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <extensions>
+        <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <arguments>
+                <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
+                </array>
+            </arguments>
+        </extension>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -1,0 +1,30 @@
+--TEST--
+With a test case that sleeps in a method with @beforeClass annotation
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/phpunit.xml
+
+...                                                                 3 / 3 (100%)
+
+Detected 2 tests that took longer than expected.
+
+1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
+2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -60,6 +60,14 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
+     * @beforeClass
+     */
+    public static function sleepWithBeforeClassAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    /**
      * @after
      */
     public function sleepWithAfterAnnotation(): void

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -27,8 +27,8 @@ Configuration: %s/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotati
 
 Detected 4 tests that took longer than expected.
 
-1. 1.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
-2. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+1. 1.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
+2. 1.0%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
 3. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
 4. 0.6%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 

--- a/test/EndToEnd/Version10/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/Combination/SleeperTest.php
@@ -71,6 +71,20 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    /**
+     * @beforeClass
+     */
+    public function sleepWithBeforeClassAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    #[Framework\Attributes\BeforeClass]
+    public function sleepWithBeforeClassAttribute(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     #[Framework\Attributes\After]
     public function sleepWithAfterAttribute(): void
     {

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/SleeperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAnnotation;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
@@ -19,56 +19,10 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\Before]
-    public function sleepWithBeforeAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\BeforeClass]
-    public static function sleepWithBeforeClassAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\After]
-    public function sleepWithAfterAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\AfterClass]
-    public static function sleepWithAfterClassAttribute(): void
+    /**
+     * @beforeClass
+     */
+    public static function sleepWithBeforeClassAnnotation(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -106,8 +60,6 @@ final class SleeperTest extends Framework\TestCase
         );
 
         foreach ($values as $value) {
-            Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-
             yield $value => [
                 $value,
             ];

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/phpunit.xml
@@ -1,0 +1,34 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -1,0 +1,32 @@
+--TEST--
+With a test case that sleeps in a method with @beforeClass annotation
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/phpunit.xml
+
+...                                                                 3 / 3 (100%)
+
+Detected 2 tests that took longer than expected.
+
+1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
+2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/SleeperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAttribute;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
@@ -19,56 +19,8 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\Before]
-    public function sleepWithBeforeAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     #[Framework\Attributes\BeforeClass]
     public static function sleepWithBeforeClassAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\After]
-    public function sleepWithAfterAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\AfterClass]
-    public static function sleepWithAfterClassAttribute(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -106,8 +58,6 @@ final class SleeperTest extends Framework\TestCase
         );
 
         foreach ($values as $value) {
-            Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-
             yield $value => [
                 $value,
             ];

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/phpunit.xml
@@ -1,0 +1,34 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/test.phpt
@@ -1,0 +1,32 @@
+--TEST--
+With a test case that sleeps in a method with BeforeClass attribute
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/phpunit.xml
+
+...                                                                 3 / 3 (100%)
+
+Detected 2 tests that took longer than expected.
+
+1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
+2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/SleeperTest.php
@@ -78,6 +78,20 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
+     * @beforeClass
+     */
+    public function sleepWithBeforeClassAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    #[Framework\Attributes\BeforeClass]
+    public function sleepWithBeforeClassAttribute(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    /**
      * @afterClass
      */
     public function sleepWithAfterClassAnnotation(): void

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
@@ -64,6 +64,20 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
+     * @beforeClass
+     */
+    public function sleepWithBeforeClassAnnotation(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    #[Framework\Attributes\BeforeClass]
+    public function sleepWithBeforeClassAttribute(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
+    /**
      * @after
      */
     public function sleepWithAfterAnnotation(): void

--- a/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/SleeperTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
-namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination;
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeClassAttribute;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Test;
 use PHPUnit\Framework;
@@ -19,56 +19,8 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function setUp(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPreConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function assertPostConditions(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    protected function tearDown(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\Before]
-    public function sleepWithBeforeAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
     #[Framework\Attributes\BeforeClass]
     public static function sleepWithBeforeClassAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\After]
-    public function sleepWithAfterAttribute(): void
-    {
-        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-    }
-
-    #[Framework\Attributes\AfterClass]
-    public static function sleepWithAfterClassAttribute(): void
     {
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
@@ -106,8 +58,6 @@ final class SleeperTest extends Framework\TestCase
         );
 
         foreach ($values as $value) {
-            Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
-
             yield $value => [
                 $value,
             ];

--- a/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/phpunit.xml
@@ -1,0 +1,34 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/test.phpt
@@ -1,0 +1,32 @@
+--TEST--
+With a test case that sleeps in a method with BeforeClass attribute
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s
+
+Runtime: %s
+Configuration: %s/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/phpunit.xml
+
+...                                                                 3 / 3 (100%)
+
+Detected 2 tests that took longer than expected.
+
+1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
+2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/SleeperTest.php
@@ -55,6 +55,12 @@ final class SleeperTest extends Framework\TestCase
         Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
     }
 
+    #[Framework\Attributes\BeforeClass]
+    public static function sleepWithBeforeClassAttribute(): void
+    {
+        Test\Fixture\Sleeper::fromMilliseconds(100)->sleep();
+    }
+
     #[Framework\Attributes\After]
     public function sleepWithAfterAttribute(): void
     {


### PR DESCRIPTION
This pull request

- [x] sleeps in methods with `@beforeClass` annotation or `BeforeClass` attribute

Related to #380.