### PR TITLE
Fix: Adjust wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Random Seed:   1676103726
 
 .............                                                                                                                                                                                                                                                                                                   13 / 13 (100%)
 
-Detected 11 tests that took longer than expected.
+Detected 11 tests where the duration exceeded the maximum duration.
 
  1. 1.604 (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Default\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider#9
  2. 1.505 (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Default\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider#8

--- a/src/Reporter/DefaultReporter.php
+++ b/src/Reporter/DefaultReporter.php
@@ -70,13 +70,13 @@ TXT;
 
         if (1 === $count) {
             return <<<TXT
-Detected {$count} test that took longer than expected.
+Detected {$count} test where the duration exceeded the maximum duration.
 
 TXT;
         }
 
         return <<<TXT
-Detected {$count} tests that took longer than expected.
+Detected {$count} tests where the duration exceeded the maximum duration.
 
 TXT;
     }

--- a/test/EndToEnd/Version07/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version07/Configuration/Defaults/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/Configuration/Defaults/phpunit.xml
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests that took longer than expected.
+Detected 11 tests where the duration exceeded the maximum duration.
 
  1. 1.6%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
  2. 1.5%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)

--- a/test/EndToEnd/Version07/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version07/Configuration/MaximumCount/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/Configuration/MaximumCount/phpunit.xml
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests that took longer than expected.
+Detected 5 tests where the duration exceeded the maximum duration.
 
 1. 1.0%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
 2. 0.9%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)

--- a/test/EndToEnd/Version07/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version07/Configuration/MaximumDuration/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/Configuration/MaximumDuration/phpunit.xml
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests that took longer than expected.
+Detected 11 tests where the duration exceeded the maximum duration.
 
  1. 1.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (1200)
  2. 1.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (1100)

--- a/test/EndToEnd/Version07/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/Bare/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/Bare/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/Combination/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/Combination/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithAfterAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/WithAfterAnnotation/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithAfterClassAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/WithAfterClassAnnotation/phpunit.x
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithAssertPostConditions/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/WithAssertPostConditions/phpunit.x
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithAssertPreConditions/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/WithAssertPreConditions/phpunit.xm
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithBeforeAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/WithBeforeAnnotation/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/WithBeforeClassAnnotation/phpunit.
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithDataProvider/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/WithDataProvider/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithSetUp/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/WithSetUp/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithSetUpBeforeClass/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/WithSetUpBeforeClass/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithTearDown/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/WithTearDown/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithTearDownAfterClass/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestCase/WithTearDownAfterClass/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestMethod/WithMaximumDurationAndSlowThresh
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithMaximumDurationAndSlowThresholdAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 

--- a/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestMethod/WithMaximumDurationAnnotation/ph
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation

--- a/test/EndToEnd/Version07/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -25,7 +25,7 @@ Configuration: %s/EndToEnd/Version07/TestMethod/WithRunInSeparateProcessAnnotati
 
 ....                                                                4 / 4 (100%)
 
-Detected 4 tests that took longer than expected.
+Detected 4 tests where the duration exceeded the maximum duration.
 
 1. 1.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
 2. 1.0%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation

--- a/test/EndToEnd/Version07/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version07/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestMethod/WithSlowThresholdAndMaximumDurat
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithSlowThresholdAndMaximumDurationAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 

--- a/test/EndToEnd/Version07/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version07/TestMethod/WithSlowThresholdAnnotation/phpu
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation

--- a/test/EndToEnd/Version08/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/Defaults/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/Configuration/Defaults/phpunit.xml
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests that took longer than expected.
+Detected 11 tests where the duration exceeded the maximum duration.
 
  1. 1.6%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
  2. 1.5%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)

--- a/test/EndToEnd/Version08/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/MaximumCount/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/Configuration/MaximumCount/phpunit.xml
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests that took longer than expected.
+Detected 5 tests where the duration exceeded the maximum duration.
 
 1. 1.0%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
 2. 0.9%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)

--- a/test/EndToEnd/Version08/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/MaximumDuration/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/Configuration/MaximumDuration/phpunit.xml
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests that took longer than expected.
+Detected 11 tests where the duration exceeded the maximum duration.
 
  1. 1.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (1200)
  2. 1.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (1100)

--- a/test/EndToEnd/Version08/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/Bare/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/Bare/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/Combination/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/Combination/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAfterAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/WithAfterAnnotation/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAfterClassAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/WithAfterClassAnnotation/phpunit.x
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/WithAssertPostConditions/phpunit.x
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/WithAssertPreConditions/phpunit.xm
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/WithBeforeAnnotation/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/phpunit.
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithDataProvider/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/WithDataProvider/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithSetUp/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/WithSetUp/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithTearDown/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/WithTearDown/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestCase/WithTearDownAfterClass/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresh
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithMaximumDurationAndSlowThresholdAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/ph
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -25,7 +25,7 @@ Configuration: %s/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotati
 
 ....                                                                4 / 4 (100%)
 
-Detected 4 tests that took longer than expected.
+Detected 4 tests where the duration exceeded the maximum duration.
 
 1. 1.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
 2. 1.0%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation

--- a/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurat
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithSlowThresholdAndMaximumDurationAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 

--- a/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/phpu
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation

--- a/test/EndToEnd/Version09/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/Defaults/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/Configuration/Defaults/phpunit.xml
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests that took longer than expected.
+Detected 11 tests where the duration exceeded the maximum duration.
 
  1. 1.6%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
  2. 1.5%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)

--- a/test/EndToEnd/Version09/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/MaximumCount/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/Configuration/MaximumCount/phpunit.xml
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests that took longer than expected.
+Detected 5 tests where the duration exceeded the maximum duration.
 
 1. 1.0%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
 2. 0.9%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)

--- a/test/EndToEnd/Version09/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/MaximumDuration/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/Configuration/MaximumDuration/phpunit.xml
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests that took longer than expected.
+Detected 11 tests where the duration exceeded the maximum duration.
 
  1. 1.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (1200)
  2. 1.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (1100)

--- a/test/EndToEnd/Version09/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/Bare/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/Bare/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/Combination/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/Combination/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAfterAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/WithAfterAnnotation/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAfterClassAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/WithAfterClassAnnotation/phpunit.x
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/WithAssertPostConditions/phpunit.x
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/WithAssertPreConditions/phpunit.xm
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/WithBeforeAnnotation/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/phpunit.
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithDataProvider/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/WithDataProvider/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithSetUp/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/WithSetUp/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithTearDown/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/WithTearDown/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestCase/WithTearDownAfterClass/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresh
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithMaximumDurationAndSlowThresholdAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/ph
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -25,7 +25,7 @@ Configuration: %s/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotati
 
 ....                                                                4 / 4 (100%)
 
-Detected 4 tests that took longer than expected.
+Detected 4 tests where the duration exceeded the maximum duration.
 
 1. 1.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
 2. 1.0%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation

--- a/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurat
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithSlowThresholdAndMaximumDurationAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 

--- a/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -20,7 +20,7 @@ Configuration: %s/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/phpu
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation

--- a/test/EndToEnd/Version10/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/Defaults/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/Configuration/Defaults/phpunit.xml
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests that took longer than expected.
+Detected 11 tests where the duration exceeded the maximum duration.
 
  1. 1.6%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider#10
  2. 1.5%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider#9

--- a/test/EndToEnd/Version10/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/MaximumCount/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/Configuration/MaximumCount/phpunit.xml
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests that took longer than expected.
+Detected 5 tests where the duration exceeded the maximum duration.
 
 1. 1.0%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider#4
 2. 0.9%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider#3

--- a/test/EndToEnd/Version10/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/MaximumDuration/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/Configuration/MaximumDuration/phpunit.xml
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests that took longer than expected.
+Detected 11 tests where the duration exceeded the maximum duration.
 
  1. 1.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#10
  2. 1.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#9

--- a/test/EndToEnd/Version10/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/Bare/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/Bare/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/Combination/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/Combination/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 1.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 1.0%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAfterAnnotation/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithAfterAnnotation/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithAfterAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAfterAttribute/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithAfterAttribute/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAfterClassAnnotation/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithAfterClassAnnotation/phpunit.x
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithAfterClassAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAfterClassAttribute/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithAfterClassAttribute/phpunit.xm
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.x
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithAssertPreConditions/phpunit.xm
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeAnnotation/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeAttribute/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/phpunit.
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/phpunit.x
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithDataProvider/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithDataProvider/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithSetUp/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithSetUp/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithTearDown/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithTearDown/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestCase/WithTearDownAfterClass/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresh
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithMaximumDurationAndSlowThresholdAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/ph
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/php
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithMaximumDurationAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAttributeWhenTestMethodHasValidMaximumDurationAttribute
 

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -27,7 +27,7 @@ Configuration: %s/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotati
 
 ....                                                                4 / 4 (100%)
 
-Detected 4 tests that took longer than expected.
+Detected 4 tests where the duration exceeded the maximum duration.
 
 1. 1.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation
 2. 1.0%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAnnotation

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
@@ -27,7 +27,7 @@ Configuration: %s/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribut
 
 ....                                                                4 / 4 (100%)
 
-Detected 4 tests that took longer than expected.
+Detected 4 tests where the duration exceeded the maximum duration.
 
 1. 1.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute
 2. 1.0%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurat
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithSlowThresholdAndMaximumDurationAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/phpu
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation

--- a/test/EndToEnd/Version11/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/Defaults/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/Configuration/Defaults/phpunit.xml
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests that took longer than expected.
+Detected 11 tests where the duration exceeded the maximum duration.
 
  1. 1.6%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider#10
  2. 1.5%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider#9

--- a/test/EndToEnd/Version11/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/MaximumCount/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/Configuration/MaximumCount/phpunit.xml
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests that took longer than expected.
+Detected 5 tests where the duration exceeded the maximum duration.
 
 1. 1.0%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider#4
 2. 0.9%s (0.500) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider#3

--- a/test/EndToEnd/Version11/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/MaximumDuration/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/Configuration/MaximumDuration/phpunit.xml
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests that took longer than expected.
+Detected 11 tests where the duration exceeded the maximum duration.
 
  1. 1.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#10
  2. 1.1%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#9

--- a/test/EndToEnd/Version11/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/Bare/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/Bare/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/Combination/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/Combination/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.9%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.8%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/WithAfterAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAfterAttribute/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/WithAfterAttribute/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/WithAfterClassAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAfterClassAttribute/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/WithAfterClassAttribute/phpunit.xm
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.x
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/WithAssertPreConditions/phpunit.xm
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/WithBeforeAttribute/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/phpunit.x
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithDataProvider/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/WithDataProvider/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithSetUp/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/WithSetUp/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithTearDown/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/WithTearDown/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.4%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestCase/WithTearDownAfterClass/phpunit.xml
 
 ...                                                                 3 / 3 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#1
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider#0

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresh
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithMaximumDurationAndSlowThresholdAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/ph
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/php
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithMaximumDurationAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAttributeWhenTestMethodHasValidMaximumDurationAttribute
 

--- a/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
@@ -27,7 +27,7 @@ Configuration: %s/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribut
 
 ....                                                                4 / 4 (100%)
 
-Detected 4 tests that took longer than expected.
+Detected 4 tests where the duration exceeded the maximum duration.
 
 1. 1.3%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute
 2. 1.0%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfigurationWhenMethodHasRunInSeparateProcessAttribute

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurat
 
 ..                                                                  2 / 2 (100%)
 
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithSlowThresholdAndMaximumDurationAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -22,7 +22,7 @@ Configuration: %s/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/phpu
 
 ....                                                                4 / 4 (100%)
 
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.3%s (0.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation
 2. 0.2%s (0.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation

--- a/test/Unit/Reporter/DefaultReporterTest.php
+++ b/test/Unit/Reporter/DefaultReporterTest.php
@@ -76,7 +76,7 @@ final class DefaultReporterTest extends Framework\TestCase
         $values = [
             'header-singular' => [
                 <<<'TXT'
-Detected 1 test that took longer than expected.
+Detected 1 test where the duration exceeded the maximum duration.
 
 1. 0.300 (0.100) FooTest::test
 TXT,
@@ -92,7 +92,7 @@ TXT,
             ],
             'header-plural' => [
                 <<<'TXT'
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.300 (0.100) FooTest::test
 2. 0.275 (0.100) BarTest::test
@@ -114,7 +114,7 @@ TXT,
             ],
             'list-sorted' => [
                 <<<'TXT'
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.300 (0.100) FooTest::test
 2. 0.275 (0.100) BarTest::test
@@ -142,7 +142,7 @@ TXT,
             ],
             'list-unsorted' => [
                 <<<'TXT'
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.300 (0.100) FooTest::test
 2. 0.275 (0.100) BarTest::test
@@ -170,7 +170,7 @@ TXT,
             ],
             'list-different-maximum-duration' => [
                 <<<'TXT'
-Detected 10 tests that took longer than expected.
+Detected 10 tests where the duration exceeded the maximum duration.
 
  1. 20:50.000 (16:40.000) FooTest::test
  2.  9:35.000 ( 8:20.000) BarTest::test
@@ -240,7 +240,7 @@ TXT,
             ],
             'footer-singular' => [
                 <<<'TXT'
-Detected 2 tests that took longer than expected.
+Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 0.300 (0.100) FooTest::test
 
@@ -263,7 +263,7 @@ TXT,
             ],
             'footer-plural' => [
                 <<<'TXT'
-Detected 3 tests that took longer than expected.
+Detected 3 tests where the duration exceeded the maximum duration.
 
 1. 0.300 (0.100) FooTest::test
 


### PR DESCRIPTION
This pull request

- [x] slightly adjusts the wording in the output of the `DefaultReporter`