### PR TITLE
Fix: Remove deprecated `beStrictAboutTodoAnnotatedTests` option for tests running on `phpunit/phpunit:^10.0.0` and `phpunit/phpunit:^11.0.0`

### DIFF
--- a/test/EndToEnd/Version10/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/Version10/Configuration/Defaults/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/Version10/Configuration/MaximumCount/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/Version10/Configuration/MaximumDuration/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/Option/NoOutput/phpunit.xml
+++ b/test/EndToEnd/Version10/Option/NoOutput/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/Bare/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/Combination/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithAfterAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithAfterAnnotation/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithAfterAttribute/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithAfterAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithAfterClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithAfterClassAnnotation/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithAfterClassAttribute/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithAfterClassAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithDataProvider/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithSetUp/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithTearDown/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version10/phpunit.xml
+++ b/test/EndToEnd/Version10/phpunit.xml
@@ -5,7 +5,6 @@
     beStrictAboutCoverageMetadata="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/Version11/Configuration/Defaults/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/Version11/Configuration/MaximumCount/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/Version11/Configuration/MaximumDuration/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/Option/NoOutput/phpunit.xml
+++ b/test/EndToEnd/Version11/Option/NoOutput/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/Bare/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/Combination/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/WithAfterAttribute/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithAfterAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/WithAfterClassAttribute/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithAfterClassAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithDataProvider/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithSetUp/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithTearDown/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"

--- a/test/EndToEnd/Version11/phpunit.xml
+++ b/test/EndToEnd/Version11/phpunit.xml
@@ -5,7 +5,6 @@
     beStrictAboutCoverageMetadata="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../vendor/autoload.php"
     cacheResult="false"
     colors="true"


### PR DESCRIPTION
This pull request

- [x] removes the deprecated `beStrictAboutTodoAnnotatedTests` option for tests running on `phpunit/phpunit:^10.0.0` and `phpunit/phpunit:^11.0.0`

💁‍♂️ For reference, see https://github.com/sebastianbergmann/phpunit/commit/dfabc5466915b727607b7434abea0900647d7d9e.