### PR TITLE
Fix: Explicitly include `src/` directory when compiling PHAR

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /.github/                       export-ignore
 /.phive/                        export-ignore
+/bin/                           export-ignore
 /phar/                          export-ignore
 /test/                          export-ignore
 /.editorconfig                  export-ignore

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -742,8 +742,13 @@ jobs:
           name: "phpunit-slow-test-detector-phar"
           path: "${{ env.PHPUNIT_SLOW_TEST_DETECTOR_PHAR }}"
 
-      - name: "Remove autoloader for composer"
-        run: "composer install --ansi --no-autoloader --no-interaction"
+      - name: "Remove autoload configuration for composer"
+        run: "php bin/remove-autoload-configuration.php"
+
+      - name: "Install ${{ matrix.dependencies }} dependencies with composer"
+        uses: "ergebnis/.github/actions/composer/install@1.9.2"
+        with:
+          dependencies: "${{ matrix.dependencies }}"
 
       - name: "Run phar tests with phpunit/phpunit:7.5.0"
         if: "matrix.phpunit-version == '7.5.0'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.15.0...main`][2.15.0...main].
 
+### Fixed
+
+- Explicitly included `src/` directory when building PHAR ([#598]), by [@localheinz]
+
 ## [`2.15.0`][2.15.0]
 
 For a full diff see [`2.14.0...2.15.0`][2.14.0...2.15.0].
@@ -337,6 +341,7 @@ For a full diff see [`7afa59c...1.0.0`][7afa59c...1.0.0].
 [#533]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/533
 [#534]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/534
 [#559]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/559
+[#598]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/598
 
 [@HypeMC]: https://github.com/HypeMC
 [@localheinz]: https://github.com/localheinz

--- a/bin/remove-autoload-configuration.php
+++ b/bin/remove-autoload-configuration.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2024 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+$composerJsonFile = __DIR__ . '/../composer.json';
+
+$composerJson = \json_decode(
+    \file_get_contents($composerJsonFile),
+    false
+);
+
+$composerJson->autoload = new stdClass();
+
+\file_put_contents($composerJsonFile, \json_encode(
+    $composerJson,
+    \JSON_PRETTY_PRINT | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES
+));

--- a/box.json
+++ b/box.json
@@ -5,6 +5,9 @@
     "KevinGH\\Box\\Compactor\\Php"
   ],
   "compression": "GZ",
+  "directories": [
+    "src/"
+  ],
   "files": [
     "manifest.xml"
   ],


### PR DESCRIPTION
This pull request

- [x] removes the autoload configuration before running tests with PHAR
- [x] explicitly includes the `src/` directory when compiling PHAR because `humbug/box` apparently filters out directories named `Test`