### PR TITLE
Fix: Remove deprecated `beStrictAboutTodoAnnotatedTests` option for tests running on `phpunit/phpunit:^10.0.0` and `phpunit/phpunit:^11.0.0`

### DIFF
--- a/test/Phar/Version10/phpunit.xml
+++ b/test/Phar/Version10/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="bootstrap.php"
     cacheResult="false"
     colors="true"

--- a/test/Phar/Version11/phpunit.xml
+++ b/test/Phar/Version11/phpunit.xml
@@ -4,7 +4,6 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
     bootstrap="bootstrap.php"
     cacheResult="false"
     colors="true"


### PR DESCRIPTION
This pull request

- [x] removes the deprecated `beStrictAboutTodoAnnotatedTests` option for tests running on `phpunit/phpunit:^10.0.0` and `phpunit/phpunit:^11.0.0`

Follows #597.