### PR TITLE
Fix: Link to schema

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/humbug/box/4.3.8/res/schema.json",
+  "$schema": "https://raw.githubusercontent.com/humbug/box/3.16.0/res/schema.json",
   "compactors": [
     "KevinGH\\Box\\Compactor\\Json",
     "KevinGH\\Box\\Compactor\\Php"


### PR DESCRIPTION
This pull request

- [x] fixes the link to the schema for `humbug/box`