### PR TITLE
Fix: Run end-to-end and phar tests with `phpunit/phpunit:8.5.40`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -756,6 +756,10 @@ jobs:
         if: "matrix.phpunit-version == '8.5.19'"
         run: "vendor/bin/phpunit --colors=always --configuration=test/EndToEnd/Version08/phpunit.xml"
 
+      - name: "Run end-to-end tests with phpunit/phpunit:8.5.40"
+        if: "matrix.phpunit-version == '8.5.40'"
+        run: "vendor/bin/phpunit --colors=always --configuration=test/EndToEnd/Version08/phpunit.xml"
+
       - name: "Run end-to-end tests with phpunit/phpunit:9.0.0"
         if: "matrix.phpunit-version == '9.0.0'"
         run: "vendor/bin/phpunit --colors=always --configuration=test/EndToEnd/Version09/phpunit.xml"
@@ -788,6 +792,10 @@ jobs:
 
       - name: "Run phar tests with phpunit/phpunit:8.5.19"
         if: "matrix.phpunit-version == '8.5.19'"
+        run: "vendor/bin/phpunit --colors=always --configuration=test/Phar/Version08/phpunit.xml"
+
+      - name: "Run phar tests with phpunit/phpunit:8.5.40"
+        if: "matrix.phpunit-version == '8.5.40'"
         run: "vendor/bin/phpunit --colors=always --configuration=test/Phar/Version08/phpunit.xml"
 
       - name: "Run phar tests with phpunit/phpunit:9.0.0"


### PR DESCRIPTION
This pull request

- [x] runs end-to-end and phar tests with `phpunit/phpunit:8.5.40`