### PR TITLE
[WIP] Fix maximumDuration annotation when using a data provider

### DIFF
--- a/test/EndToEnd/Version06/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version06/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
@@ -63,6 +63,25 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
+    public function mockDataProvider() {
+        return array(array('mockArgument'));
+    }
+
+    /**
+     * @maximumDuration 200
+     * @dataProvider mockDataProvider
+     */
+    public function testSleeperSleepsShorterThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotationAndDataProvider()
+    {
+        $milliseconds = 150;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
     /**
      * @maximumDuration 200
      */

--- a/test/EndToEnd/Version06/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version06/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -18,7 +18,7 @@ PHPUnit %s
 Runtime: %s
 Configuration: %s/EndToEnd/Version06/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
 
-....                                                                4 / 4 (100%)
+.....                                                               5 / 5 (100%)
 
 Detected 2 tests where the duration exceeded the maximum duration.
 
@@ -27,4 +27,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 
 Time: %s, Memory: %s
 
-OK (4 tests, 4 assertions)
+OK (5 tests, 5 assertions)

--- a/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
@@ -63,6 +63,25 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
+    public function mockDataProvider() {
+        return array(array('mockArgument'));
+    }
+
+    /**
+     * @maximumDuration 200
+     * @dataProvider mockDataProvider
+     */
+    public function testSleeperSleepsShorterThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotationAndDataProvider(): void
+    {
+        $milliseconds = 150;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
     /**
      * @maximumDuration 200
      */

--- a/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -18,7 +18,7 @@ PHPUnit %s
 Runtime: %s
 Configuration: %s/EndToEnd/Version07/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
 
-....                                                                4 / 4 (100%)
+.....                                                               5 / 5 (100%)
 
 Detected 2 tests where the duration exceeded the maximum duration.
 
@@ -27,4 +27,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 
 Time: %s, Memory: %s
 
-OK (4 tests, 4 assertions)
+OK (5 tests, 5 assertions)

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
@@ -63,6 +63,25 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
+    public function mockDataProvider() {
+        return array(array('mockArgument'));
+    }
+
+    /**
+     * @maximumDuration 200
+     * @dataProvider mockDataProvider
+     */
+    public function testSleeperSleepsShorterThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotationAndDataProvider(): void
+    {
+        $milliseconds = 150;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
     /**
      * @maximumDuration 200
      */

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -18,7 +18,7 @@ PHPUnit %s
 Runtime: %s
 Configuration: %s/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
 
-....                                                                4 / 4 (100%)
+.....                                                               5 / 5 (100%)
 
 Detected 2 tests where the duration exceeded the maximum duration.
 
@@ -27,4 +27,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 
 Time: %s, Memory: %s
 
-OK (4 tests, 4 assertions)
+OK (5 tests, 5 assertions)

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
@@ -63,6 +63,25 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
+    public function mockDataProvider() {
+        return array(array('mockArgument'));
+    }
+
+    /**
+     * @maximumDuration 200
+     * @dataProvider mockDataProvider
+     */
+    public function testSleeperSleepsShorterThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotationAndDataProvider(): void
+    {
+        $milliseconds = 150;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
     /**
      * @maximumDuration 200
      */

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -18,7 +18,7 @@ PHPUnit %s
 Runtime: %s
 Configuration: %s/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
 
-....                                                                4 / 4 (100%)
+.....                                                               5 / 5 (100%)
 
 Detected 2 tests where the duration exceeded the maximum duration.
 
@@ -27,4 +27,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 
 Time: %s, Memory: %s
 
-OK (4 tests, 4 assertions)
+OK (5 tests, 5 assertions)

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
@@ -61,6 +61,25 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
+    public function mockDataProvider() {
+        return array(array('mockArgument'));
+    }
+
+    /**
+     * @maximumDuration 200
+     * @dataProvider mockDataProvider
+     */
+    public function testSleeperSleepsShorterThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotationAndDataProvider(): void
+    {
+        $milliseconds = 150;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
     /**
      * @maximumDuration 200
      */

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -20,7 +20,7 @@ PHPUnit %s
 Runtime: %s
 Configuration: %s/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
 
-....                                                                4 / 4 (100%)
+.....                                                               5 / 5 (100%)
 
 Detected 2 tests where the duration exceeded the maximum duration.
 
@@ -29,4 +29,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 
 Time: %s, Memory: %s
 
-OK (4 tests, 4 assertions)
+OK (5 tests, 5 assertions)

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/SleeperTest.php
@@ -61,6 +61,25 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
+    public function mockDataProvider() {
+        return array(array('mockArgument'));
+    }
+
+    /**
+     * @maximumDuration 200
+     * @dataProvider mockDataProvider
+     */
+    public function testSleeperSleepsShorterThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotationAndDataProvider(): void
+    {
+        $milliseconds = 150;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
     /**
      * @maximumDuration 200
      */

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -20,7 +20,7 @@ PHPUnit %s
 Runtime: %s
 Configuration: %s/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
 
-....                                                                4 / 4 (100%)
+.....                                                               5 / 5 (100%)
 
 Detected 2 tests where the duration exceeded the maximum duration.
 
@@ -29,4 +29,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 
 Time: %s, Memory: %s
 
-OK (4 tests, 4 assertions)
+OK (5 tests, 5 assertions)


### PR DESCRIPTION
Currently, the maximumDuration annotation does not work when a test uses a PHPUnit data provider.  This PR fixes discovery of the maximumDuration annotation .
