### PR TITLE
Fix discovery of `@maximumDuration` annotation when test-cases have no test methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ For a full diff see [`2.20.0...main`][2.20.0...main].
 - Added support for `phpunit/phpunit:^13.0.0` ([#757]), by [@localheinz]
 - Added support for PHP 8.5 ([#713]), by [@localheinz]
 
+### Fixed
+
+- Fixed discovery of `@maximumDuration` annotation when a test case does not have any test methods ([#687]), by [@courtney-miles]
+
 ### Security
 
 - Ignored `CVE-2026-24765` security advisory in `composer.json` configuration because this package needs to support versions of `phpunit/phpunit` affected by this vulnerability ([#754]), by [@localheinz]
@@ -436,6 +440,7 @@ For a full diff see [`7afa59c...1.0.0`][7afa59c...1.0.0].
 [#754]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/754
 [#757]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/757
 
+[@courtney-miles]: https://github.com/courtney-miles
 [@dantleech]: https://github.com/dantleech
 [@HypeMC]: https://github.com/HypeMC
 [@localheinz]: https://github.com/localheinz

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -371,6 +371,10 @@ TXT;
                 );
             }
 
+            if (\strpos($test, '::') === false) {
+                return $this->maximumDuration;
+            }
+
             list($testClassName, $testMethodName) = \explode(
                 '::',
                 $test

--- a/test/EndToEnd/Version06/TestCase/WithoutTestMethods/SleeperTest.php
+++ b/test/EndToEnd/Version06/TestCase/WithoutTestMethods/SleeperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithoutTestMethods;
+
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture\Sleeper
+ */
+final class SleeperTest extends Framework\TestCase
+{
+}

--- a/test/EndToEnd/Version06/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/Version06/TestCase/WithoutTestMethods/phpunit.xml
@@ -1,0 +1,34 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.5/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    colors="true"
+    columns="max"
+    forceCoversAnnotation="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <listeners>
+        <listener class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <arguments>
+                <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
+                </array>
+            </arguments>
+        </listener>
+    </listeners>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version06/TestCase/WithoutTestMethods/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithoutTestMethods/test.phpt
@@ -1,0 +1,20 @@
+--TEST--
+With a test case that has no test methods
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version06/TestCase/WithoutTestMethods/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+%a
+
+W                                                                   1 / 1 (100%)
+
+%a

--- a/test/EndToEnd/Version07/TestCase/WithoutTestMethods/SleeperTest.php
+++ b/test/EndToEnd/Version07/TestCase/WithoutTestMethods/SleeperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithoutTestMethods;
+
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture\Sleeper
+ */
+final class SleeperTest extends Framework\TestCase
+{
+}

--- a/test/EndToEnd/Version07/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/Version07/TestCase/WithoutTestMethods/phpunit.xml
@@ -1,0 +1,34 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    colors="true"
+    columns="max"
+    forceCoversAnnotation="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <extensions>
+        <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <arguments>
+                <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
+                </array>
+            </arguments>
+        </extension>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version07/TestCase/WithoutTestMethods/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithoutTestMethods/test.phpt
@@ -1,0 +1,20 @@
+--TEST--
+With a test case that has no test methods
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version07/TestCase/WithoutTestMethods/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+%a
+
+W                                                                   1 / 1 (100%)
+
+%a

--- a/test/EndToEnd/Version08/TestCase/WithoutTestMethods/SleeperTest.php
+++ b/test/EndToEnd/Version08/TestCase/WithoutTestMethods/SleeperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithoutTestMethods;
+
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture\Sleeper
+ */
+final class SleeperTest extends Framework\TestCase
+{
+}

--- a/test/EndToEnd/Version08/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/Version08/TestCase/WithoutTestMethods/phpunit.xml
@@ -1,0 +1,36 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    executionOrder="default"
+    forceCoversAnnotation="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <extensions>
+        <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <arguments>
+                <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
+                </array>
+            </arguments>
+        </extension>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version08/TestCase/WithoutTestMethods/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithoutTestMethods/test.phpt
@@ -1,0 +1,20 @@
+--TEST--
+With a test case that has no test methods
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version08/TestCase/WithoutTestMethods/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+%a
+
+W                                                                   1 / 1 (100%)
+
+%a

--- a/test/EndToEnd/Version09/TestCase/WithoutTestMethods/SleeperTest.php
+++ b/test/EndToEnd/Version09/TestCase/WithoutTestMethods/SleeperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithoutTestMethods;
+
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture\Sleeper
+ */
+final class SleeperTest extends Framework\TestCase
+{
+}

--- a/test/EndToEnd/Version09/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/Version09/TestCase/WithoutTestMethods/phpunit.xml
@@ -1,0 +1,36 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    executionOrder="default"
+    forceCoversAnnotation="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="true"
+>
+    <extensions>
+        <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <arguments>
+                <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
+                </array>
+            </arguments>
+        </extension>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version09/TestCase/WithoutTestMethods/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithoutTestMethods/test.phpt
@@ -1,0 +1,20 @@
+--TEST--
+With a test case that has no test methods
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version09/TestCase/WithoutTestMethods/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+%a
+
+W                                                                   1 / 1 (100%)
+
+%a

--- a/test/EndToEnd/Version10/TestCase/WithoutTestMethods/SleeperTest.php
+++ b/test/EndToEnd/Version10/TestCase/WithoutTestMethods/SleeperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithoutTestMethods;
+
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture\Sleeper
+ */
+final class SleeperTest extends Framework\TestCase
+{
+}

--- a/test/EndToEnd/Version10/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/Version10/TestCase/WithoutTestMethods/phpunit.xml
@@ -1,0 +1,33 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version10/TestCase/WithoutTestMethods/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithoutTestMethods/test.phpt
@@ -1,0 +1,24 @@
+--TEST--
+With a test case that has no test methods
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version10/TestCase/WithoutTestMethods/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+%a
+
+There was 1 PHPUnit%swarning:
+
+1) No tests found in class "Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithoutTestMethods\SleeperTest".
+
+No tests executed!

--- a/test/EndToEnd/Version11/TestCase/WithoutTestMethods/SleeperTest.php
+++ b/test/EndToEnd/Version11/TestCase/WithoutTestMethods/SleeperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithoutTestMethods;
+
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture\Sleeper
+ */
+final class SleeperTest extends Framework\TestCase
+{
+}

--- a/test/EndToEnd/Version11/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/Version11/TestCase/WithoutTestMethods/phpunit.xml
@@ -1,0 +1,33 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version11/TestCase/WithoutTestMethods/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithoutTestMethods/test.phpt
@@ -1,0 +1,24 @@
+--TEST--
+With a test case that has no test methods
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version11/TestCase/WithoutTestMethods/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+%a
+
+There was 1 PHPUnit test runner warning:
+
+1) No tests found in class "Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithoutTestMethods\SleeperTest".
+
+No tests executed!

--- a/test/EndToEnd/Version12/TestCase/WithoutTestMethods/SleeperTest.php
+++ b/test/EndToEnd/Version12/TestCase/WithoutTestMethods/SleeperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithoutTestMethods;
+
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Test\Fixture\Sleeper
+ */
+final class SleeperTest extends Framework\TestCase
+{
+}

--- a/test/EndToEnd/Version12/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/Version12/TestCase/WithoutTestMethods/phpunit.xml
@@ -1,0 +1,33 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version12/TestCase/WithoutTestMethods/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithoutTestMethods/test.phpt
@@ -1,0 +1,24 @@
+--TEST--
+With a test case that has no test methods
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version12/TestCase/WithoutTestMethods/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+%a
+
+There was 1 PHPUnit test runner warning:
+
+1) No tests found in class "Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithoutTestMethods\SleeperTest".
+
+No tests executed!

--- a/test/EndToEnd/Version13/TestCase/WithoutTestMethods/SleeperTest.php
+++ b/test/EndToEnd/Version13/TestCase/WithoutTestMethods/SleeperTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version13\TestCase\WithoutTestMethods;
+
+use Ergebnis\PHPUnit\SlowTestDetector\Test;
+use PHPUnit\Framework;
+
+#[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
+final class SleeperTest extends Framework\TestCase
+{
+}

--- a/test/EndToEnd/Version13/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/Version13/TestCase/WithoutTestMethods/phpunit.xml
@@ -1,0 +1,33 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/Version13/TestCase/WithoutTestMethods/test.phpt
+++ b/test/EndToEnd/Version13/TestCase/WithoutTestMethods/test.phpt
@@ -1,0 +1,24 @@
+--TEST--
+With a test case that has no test methods
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/Version13/TestCase/WithoutTestMethods/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+%a
+
+There was 1 PHPUnit test runner warning:
+
+1) No tests found in class "Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version13\TestCase\WithoutTestMethods\SleeperTest".
+
+No tests executed!


### PR DESCRIPTION
This fixes a warning triggered when discovering the maximum duration for a test-case class that has no test methods.

Fixes #686
