### PR TITLE
Fix: Focus on relevant output in end-to-end tests

### DIFF
--- a/test/EndToEnd/Version06/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version06/Configuration/Defaults/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/Configuration/Defaults/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -35,6 +32,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version06/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version06/Configuration/MaximumCount/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/Configuration/MaximumCount/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -28,6 +25,4 @@ Detected 5 tests where the duration exceeded the maximum duration.
 
 There are 2 additional slow tests that are not listed here.
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version06/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version06/Configuration/MaximumDuration/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/Configuration/MaximumDuration/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -35,6 +32,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/Bare/test.phpt
@@ -13,18 +13,11 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/Bare/phpunit.xml
-
-...                                                                 3 / 3 (100%)
+%a
 
 Detected 2 tests where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/Combination/test.phpt
@@ -13,11 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/Combination/phpunit.xml
-
+%a
 ...                                                                 3 / 3 (100%)
 
 Detected 3 tests where the duration exceeded the maximum duration.
@@ -26,6 +22,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithAfterAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/WithAfterAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithAfterClassAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/WithAfterClassAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithAssertPostConditions/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/WithAssertPostConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithAssertPreConditions/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/WithAssertPreConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithBeforeAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/WithBeforeAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/WithBeforeClassAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithDataProvider/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/WithDataProvider/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithSetUp/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/WithSetUp/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithSetUpBeforeClass/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/WithSetUpBeforeClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithTearDown/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/WithTearDown/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version06/TestCase/WithTearDownAfterClass/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestCase/WithTearDownAfterClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version06/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version06/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -24,6 +21,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestMethod\WithMaximumDurationAndSlowThresholdAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version06/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version06/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version06/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version06/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -18,10 +18,7 @@ require_once PHPUNIT_COMPOSER_INSTALL;
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -32,6 +29,4 @@ Detected 4 tests where the duration exceeded the maximum duration.
 3. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
 4. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version06/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version06/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -24,6 +21,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestMethod\WithSlowThresholdAndMaximumDurationAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version06/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version06/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version06/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version06\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version07/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version07/Configuration/Defaults/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/Configuration/Defaults/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -35,6 +32,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version07/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version07/Configuration/MaximumCount/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/Configuration/MaximumCount/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -28,6 +25,4 @@ Detected 5 tests where the duration exceeded the maximum duration.
 
 There are 2 additional slow tests that are not listed here.
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version07/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version07/Configuration/MaximumDuration/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/Configuration/MaximumDuration/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -35,6 +32,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/Bare/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/Bare/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/Combination/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/Combination/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithAfterAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/WithAfterAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithAfterClassAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/WithAfterClassAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithAssertPostConditions/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/WithAssertPostConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithAssertPreConditions/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/WithAssertPreConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithBeforeAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/WithBeforeAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/WithBeforeClassAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithDataProvider/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/WithDataProvider/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithSetUp/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/WithSetUp/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithSetUpBeforeClass/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/WithSetUpBeforeClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithTearDown/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/WithTearDown/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version07/TestCase/WithTearDownAfterClass/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestCase/WithTearDownAfterClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -24,6 +21,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithMaximumDurationAndSlowThresholdAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version07/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -18,10 +18,7 @@ require_once PHPUNIT_COMPOSER_INSTALL;
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -32,6 +29,4 @@ Detected 4 tests where the duration exceeded the maximum duration.
 3. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
 4. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version07/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version07/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -24,6 +21,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithSlowThresholdAndMaximumDurationAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version07/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version07/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version07/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version07\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version08/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/Defaults/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/Configuration/Defaults/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -35,6 +32,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version08/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/MaximumCount/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/Configuration/MaximumCount/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -28,6 +25,4 @@ Detected 5 tests where the duration exceeded the maximum duration.
 
 There are 2 additional slow tests that are not listed here.
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version08/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version08/Configuration/MaximumDuration/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/Configuration/MaximumDuration/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -35,6 +32,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/Bare/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/Bare/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/Combination/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/Combination/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAfterAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/WithAfterAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAfterClassAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/WithAfterClassAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPostConditions/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/WithAssertPostConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithAssertPreConditions/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/WithAssertPreConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithBeforeAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/WithBeforeAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/WithBeforeClassAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithDataProvider/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/WithDataProvider/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithSetUp/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/WithSetUp/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/WithSetUpBeforeClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithTearDown/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/WithTearDown/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version08/TestCase/WithTearDownAfterClass/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestCase/WithTearDownAfterClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -24,6 +21,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithMaximumDurationAndSlowThresholdAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -18,10 +18,7 @@ require_once PHPUNIT_COMPOSER_INSTALL;
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -32,6 +29,4 @@ Detected 4 tests where the duration exceeded the maximum duration.
 3. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
 4. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -24,6 +21,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithSlowThresholdAndMaximumDurationAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version08/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version08\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version09/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/Defaults/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/Configuration/Defaults/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -35,6 +32,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version09/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/MaximumCount/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/Configuration/MaximumCount/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -28,6 +25,4 @@ Detected 5 tests where the duration exceeded the maximum duration.
 
 There are 2 additional slow tests that are not listed here.
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version09/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version09/Configuration/MaximumDuration/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/Configuration/MaximumDuration/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -35,6 +32,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/Bare/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/Bare/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/Combination/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/Combination/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAfterAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/WithAfterAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAfterClassAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/WithAfterClassAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPostConditions/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/WithAssertPostConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithAssertPreConditions/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/WithAssertPreConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithBeforeAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/WithBeforeAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/WithBeforeClassAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithDataProvider/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/WithDataProvider/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithSetUp/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/WithSetUp/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/WithSetUpBeforeClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithTearDown/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/WithTearDown/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -26,6 +23,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version09/TestCase/WithTearDownAfterClass/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestCase/WithTearDownAfterClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -24,6 +21,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithMaximumDurationAndSlowThresholdAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -18,10 +18,7 @@ require_once PHPUNIT_COMPOSER_INSTALL;
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -32,6 +29,4 @@ Detected 4 tests where the duration exceeded the maximum duration.
 3. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
 4. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -24,6 +21,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithSlowThresholdAndMaximumDurationAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -13,10 +13,7 @@ require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version09/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -25,6 +22,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version09\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version10/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/Defaults/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/Configuration/Defaults/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -37,6 +34,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version10/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/MaximumCount/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/Configuration/MaximumCount/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -30,6 +27,4 @@ Detected 5 tests where the duration exceeded the maximum duration.
 
 There are 2 additional slow tests that are not listed here.
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version10/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version10/Configuration/MaximumDuration/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/Configuration/MaximumDuration/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -37,6 +34,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/Bare/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/Bare/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/Combination/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/Combination/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:01.0%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAfterAnnotation/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithAfterAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithAfterAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAfterAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithAfterAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAfterClassAnnotation/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithAfterClassAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithAfterClassAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAfterClassAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithAfterClassAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPostConditions/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithAssertPostConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithAssertPreConditions/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithAssertPreConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAnnotation/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeClassAnnotation/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithBeforeClassAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithDataProvider/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithDataProvider/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithSetUp/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithSetUp/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithSetUpBeforeClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithTearDown/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithTearDown/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version10/TestCase/WithTearDownAfterClass/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestCase/WithTearDownAfterClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -26,6 +23,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithMaximumDurationAndSlowThresholdAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestMethod/WithMaximumDurationAttribute/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -26,6 +23,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithMaximumDurationAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAttributeWhenTestMethodHasValidMaximumDurationAttribute
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/test.phpt
@@ -20,10 +20,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -34,6 +31,4 @@ Detected 4 tests where the duration exceeded the maximum duration.
 3. 00:01.0%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
 4. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAnnotation\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
@@ -20,10 +20,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -34,6 +31,4 @@ Detected 4 tests where the duration exceeded the maximum duration.
 3. 00:01.0%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
 4. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -26,6 +23,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithSlowThresholdAndMaximumDurationAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version10/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version10\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version11/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/Defaults/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/Configuration/Defaults/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -37,6 +34,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version11/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/MaximumCount/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/Configuration/MaximumCount/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -30,6 +27,4 @@ Detected 5 tests where the duration exceeded the maximum duration.
 
 There are 2 additional slow tests that are not listed here.
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version11/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version11/Configuration/MaximumDuration/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/Configuration/MaximumDuration/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -37,6 +34,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/Bare/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/Bare/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/Combination/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/Combination/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/WithAfterAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAfterAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/WithAfterAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/WithAfterClassAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAfterClassAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/WithAfterClassAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPostConditions/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/WithAssertPostConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithAssertPreConditions/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/WithAssertPreConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/WithBeforeAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/WithBeforeClassAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithDataProvider/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/WithDataProvider/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithSetUp/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/WithSetUp/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/WithSetUpBeforeClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithTearDown/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/WithTearDown/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version11/TestCase/WithTearDownAfterClass/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestCase/WithTearDownAfterClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -26,6 +23,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithMaximumDurationAndSlowThresholdAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -27,7 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasValidMaximumDurationAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithMaximumDurationAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidMaximumDurationAnnotation
 
-Time: %s, Memory: %s
-%A
-OK, but there were issues!
-Tests: 6, Assertions: 6, %ADeprecations: 2.
+%a

--- a/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestMethod/WithMaximumDurationAttribute/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -26,6 +23,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithMaximumDurationAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAttributeWhenTestMethodHasValidMaximumDurationAttribute
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
@@ -20,10 +20,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -34,6 +31,4 @@ Detected 4 tests where the duration exceeded the maximum duration.
 3. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
 4. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -26,6 +23,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithSlowThresholdAndMaximumDurationAnnotations\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAnnotationWhenTestMethodHasMaximumDurationAndSlowThresholdAnnotations
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/test.phpt
+++ b/test/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version11/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanSlowThresholdFromAnnotationWhenTestMethodHasValidSlowThresholdAnnotation
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version11\TestMethod\WithSlowThresholdAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWhenTestMethodHasInvalidSlowThresholdAnnotation
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a

--- a/test/EndToEnd/Version12/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/Version12/Configuration/Defaults/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/Configuration/Defaults/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -37,6 +34,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version12/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/Version12/Configuration/MaximumCount/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/Configuration/MaximumCount/phpunit.xml
+%a
 
 ......                                                              6 / 6 (100%)
 
@@ -30,6 +27,4 @@ Detected 5 tests where the duration exceeded the maximum duration.
 
 There are 2 additional slow tests that are not listed here.
 
-Time: %s, Memory: %s
-
-OK (6 tests, 6 assertions)
+%a

--- a/test/EndToEnd/Version12/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/Version12/Configuration/MaximumDuration/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/Configuration/MaximumDuration/phpunit.xml
+%a
 
 ............                                                      12 / 12 (100%)
 
@@ -37,6 +34,4 @@ Detected 11 tests where the duration exceeded the maximum duration.
 
 There is 1 additional slow test that is not listed here.
 
-Time: %s, Memory: %s
-
-OK (12 tests, 12 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/Bare/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/Bare/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/Combination/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/Combination/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/WithAfterAttribute/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithAfterAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/WithAfterAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/WithAfterClassAttribute/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithAfterClassAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/WithAfterClassAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithAssertPostConditions/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/WithAssertPostConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithAssertPreConditions/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/WithAssertPreConditions/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/WithBeforeAttribute/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithBeforeAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/WithBeforeAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/WithBeforeClassAttribute/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithBeforeClassAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/WithBeforeClassAttribute/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithDataProvider/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/WithDataProvider/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithSetUp/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/WithSetUp/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithSetUpBeforeClass/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/WithSetUpBeforeClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithTearDown/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/WithTearDown/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -28,6 +25,4 @@ Detected 3 tests where the duration exceeded the maximum duration.
 2. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 3. 00:00.1%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/Version12/TestCase/WithTearDownAfterClass/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestCase/WithTearDownAfterClass/phpunit.xml
+%a
 
 ...                                                                 3 / 3 (100%)
 
@@ -27,6 +24,4 @@ Detected 2 tests where the duration exceeded the maximum duration.
 1. 00:00.3%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
 2. 00:00.2%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+%a

--- a/test/EndToEnd/Version12/TestMethod/WithMaximumDurationAttribute/test.phpt
+++ b/test/EndToEnd/Version12/TestMethod/WithMaximumDurationAttribute/test.phpt
@@ -15,10 +15,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestMethod/WithMaximumDurationAttribute/phpunit.xml
+%a
 
 ..                                                                  2 / 2 (100%)
 
@@ -26,6 +23,4 @@ Detected 1 test where the duration exceeded the maximum duration.
 
 1. 00:00.3%s (00:00.200) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestMethod\WithMaximumDurationAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromAttributeWhenTestMethodHasValidMaximumDurationAttribute
 
-Time: %s, Memory: %s
-
-OK (2 tests, 2 assertions)
+%a

--- a/test/EndToEnd/Version12/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
+++ b/test/EndToEnd/Version12/TestMethod/WithRunInSeparateProcessAttribute/test.phpt
@@ -20,10 +20,7 @@ $application = new TextUI\Application();
 
 $application->run($_SERVER['argv']);
 --EXPECTF--
-PHPUnit %s
-
-Runtime: %s
-Configuration: %s/EndToEnd/Version12/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
+%a
 
 ....                                                                4 / 4 (100%)
 
@@ -34,6 +31,4 @@ Detected 4 tests where the duration exceeded the maximum duration.
 3. 00:00.8%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration
 4. 00:00.6%s (00:00.100) Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\Version12\TestMethod\WithRunInSeparateProcessAttribute\SleeperTest::testSleeperSleepsShorterThanMaximumDurationFromXmlConfiguration
 
-Time: %s, Memory: %s
-
-OK (4 tests, 4 assertions)
+%a


### PR DESCRIPTION
This pull request

- [x] focuses on the relevant output in end-to-end tests

Related to #687.