### PR TITLE
PHPUnit diff config file confusion about extension initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ adjust your `phpunit.xml` configuration file and configure the
 +    extensionsDirectory="directory/where/you/saved/the/extension/phars"
  >
 +    <extensions>
-+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
++        <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
 +    </extensions>
      <testsuites>
          <testsuite name="unit">
@@ -182,7 +182,7 @@ adjust your `phpunit.xml` configuration file and configure the
 +    extensionsDirectory="directory/where/you/saved/the/extension/phars"
  >
 +    <extensions>
-+        <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
++        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
 +    </extensions>
      <testsuites>
          <testsuite name="unit">


### PR DESCRIPTION
PHPUnit diff config file confusion about extension initialization, for PHAR bootstrapping, between versions 7,8,9 and 10,11,12

Confirmed by official PHPUnit documentation : 

Uses `extensions/extension`

- https://docs.phpunit.de/en/7.5/configuration.html#the-extensions-element
- https://docs.phpunit.de/en/8.5/configuration.html#the-extensions-element
- https://docs.phpunit.de/en/9.6/configuration.html#the-extensions-element

Uses `extensions/bootstrap`

- https://docs.phpunit.de/en/10.5/configuration.html#the-extensions-element
- https://docs.phpunit.de/en/11.5/configuration.html#the-extensions-element
- https://docs.phpunit.de/en/12.3/configuration.html#the-extensions-element

