### PR TITLE
Fix: Handle test names without :: separator in resolveMaximumDuration

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -371,6 +371,10 @@ TXT;
                 );
             }
 
+            if (!\str_contains($test, '::')) {
+                return $this->maximumDuration;
+            }
+
             list($testClassName, $testMethodName) = \explode(
                 '::',
                 $test

--- a/test/Unit/ExtensionTest.php
+++ b/test/Unit/ExtensionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\Unit;
+
+use Ergebnis\PHPUnit\SlowTestDetector\Extension;
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Extension
+ */
+final class ExtensionTest extends Framework\TestCase
+{
+    /**
+     * Tests that executeAfterTest handles test names without '::' separator gracefully.
+     *
+     * This can occur when:
+     * - A test class has errors during setUpBeforeClass() or class loading
+     * - PHPUnit generates warning-type test entries
+     * - Tests are defined in unusual ways (anonymous classes, generated tests)
+     * - Memory exhaustion or fatal errors occur during test execution
+     */
+    public function testExecuteAfterTestHandlesTestNameWithoutDoubleColonSeparator(): void
+    {
+        $phpUnitVersionSeries = \PHPUnit\Runner\Version::series();
+
+        if (\version_compare($phpUnitVersionSeries, '7.0', '<') || \version_compare($phpUnitVersionSeries, '10.0', '>=')) {
+            self::markTestSkipped('This test only applies to PHPUnit 7/8/9 where AfterTestHook is used.');
+        }
+
+        $extension = new Extension();
+
+        /** @phpstan-ignore method.notFound (method only exists for PHPUnit 7/8/9) */
+        $extension->executeBeforeFirstTest();
+
+        $testNameWithoutDoubleColon = 'SomeWarningOrErrorMessage';
+
+        /** @phpstan-ignore method.notFound (method only exists for PHPUnit 7/8/9) */
+        $extension->executeAfterTest($testNameWithoutDoubleColon, 2.0);
+
+        $this->expectOutputRegex('/.*/');
+
+        /** @phpstan-ignore method.notFound (method only exists for PHPUnit 7/8/9) */
+        $extension->executeAfterLastTest();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #744

This PR fixes a crash in `resolveMaximumDuration` when PHPUnit's `AfterTestHook::executeAfterTest()` passes a test identifier that does not contain the expected `::` separator.

## Problem

The `explode('::', $test)` call on line 374 assumes all test names contain `::`. When they don't (which can happen during setup failures, warning-type test entries, or unusual test definitions), unpacking fails with:

```
Warning: Undefined array key 1 in .../Extension.php on line 374
```

## Solution

Added a guard clause to check for the `::` separator before attempting to parse the test name. If not present, the method returns the default maximum duration:

```php
if (!\str_contains($test, '::')) {
    return $this->maximumDuration;
}
```

## Testing

Added a new unit test `ExtensionTest::testExecuteAfterTestHandlesTestNameWithoutDoubleColonSeparator()` that:
1. Creates an Extension instance
2. Calls `executeAfterTest()` with a test name that doesn't contain `::`
3. Verifies no exception is thrown

All existing tests continue to pass.

## Checklist

- [x] Fix applied to PHPUnit 7/8/9 code path
- [x] Unit test added to reproduce and verify the fix
- [x] All existing tests pass
- [x] Code style checks pass
