### PR TITLE
Enhancement: Add PHPUnit 10/11/12 attribute errors to phpstan baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,6 +61,21 @@ parameters:
 			path: test/Fixture/Sleeper.php
 
 		-
+			message: "#^Attribute class PHPUnit\\\\Framework\\\\Attributes\\\\CoversClass does not exist\\.$#"
+			count: 1
+			path: test/Phar/Version10/SleeperTest.php
+
+		-
+			message: "#^Attribute class PHPUnit\\\\Framework\\\\Attributes\\\\CoversClass does not exist\\.$#"
+			count: 1
+			path: test/Phar/Version11/SleeperTest.php
+
+		-
+			message: "#^Attribute class PHPUnit\\\\Framework\\\\Attributes\\\\CoversClass does not exist\\.$#"
+			count: 1
+			path: test/Phar/Version12/SleeperTest.php
+
+		-
 			message: "#^Method Ergebnis\\\\PHPUnit\\\\SlowTestDetector\\\\Test\\\\Unit\\\\Attribute\\\\MaximumDurationTest\\:\\:testConstructorRejectsInvalidValue\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: test/Unit/Attribute/MaximumDurationTest.php


### PR DESCRIPTION
## Summary

This PR adds the `PHPUnit\Framework\Attributes\CoversClass` attribute errors to the phpstan baseline.

## Problem

When running `make static-code-analysis` with PHPUnit 9 installed (the default when running `composer install`), phpstan reports errors for the PHPUnit 10/11/12 test files that use attributes:

```
test/Phar/Version10/SleeperTest.php - Attribute class PHPUnit\Framework\Attributes\CoversClass does not exist.
test/Phar/Version11/SleeperTest.php - Attribute class PHPUnit\Framework\Attributes\CoversClass does not exist.
test/Phar/Version12/SleeperTest.php - Attribute class PHPUnit\Framework\Attributes\CoversClass does not exist.
```

These errors occur because the `CoversClass` attribute was introduced in PHPUnit 10, but phpstan runs against whatever PHPUnit version is installed (typically 9.x based on the platform config).

## Solution

Regenerated the phpstan baseline to include these expected errors, allowing `make static-code-analysis` to pass.

## Verification

```bash
make static-code-analysis
# [OK] No errors
```
