### PR TITLE
Fix: Create release in draft mode, upload assets, and then publish release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,6 +101,7 @@ jobs:
       - name: "Create release"
         uses: "ergebnis/.github/actions/github/release/create@1.10.0"
         with:
+          draft: "true"
           github-token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
 
       - name: "Upload release assets"
@@ -135,6 +136,12 @@ jobs:
                 core.setFailed(error.message);
               }
             }
+
+      - name: "Publish release"
+        uses: "ergebnis/.github/actions/github/release/publish@1.10.0"
+        with:
+          github-token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
+          release-id: "${{ env.RELEASE_ID }}"
 
       - name: "Post to twitter.com about release"
         uses: "Eomm/why-don-t-you-tweet@v2.0.0"


### PR DESCRIPTION
This pull request

- [x] creates a release in draft mode, uploads assets, and then publishes the release
