### PR TITLE
Fix: Pull printing of empty lines into `DefaultReporter`

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -140,7 +140,7 @@ if ($phpUnitVersionSeries->major()->equals(Version\Major::fromInt(6))) {
                 return;
             }
 
-            echo "\n\n" . $report;
+            echo $report;
         }
 
         public function startTest(Framework\Test $test)
@@ -341,7 +341,7 @@ if ($phpUnitVersionSeries->major()->isOneOf(Version\Major::fromInt(7), Version\M
                 return;
             }
 
-            echo "\n\n" . $report;
+            echo $report;
         }
 
         private function resolveMaximumDuration(string $test): MaximumDuration

--- a/src/Reporter/DefaultReporter.php
+++ b/src/Reporter/DefaultReporter.php
@@ -43,11 +43,15 @@ final class DefaultReporter implements Reporter
 
     public function report(SlowTestList $slowTestList): string
     {
-        if ($slowTestList->isEmpty()) {
+        $lines = \iterator_to_array($this->lines($slowTestList));
+
+        if ([] === $lines) {
             return '';
         }
 
-        return \implode("\n", \iterator_to_array($this->lines($slowTestList)));
+        return \implode('', \array_map(static function (string $line): string {
+            return $line . "\n";
+        }, $lines));
     }
 
     /**
@@ -56,6 +60,14 @@ final class DefaultReporter implements Reporter
     private function lines(SlowTestList $slowTestList): \Generator
     {
         $slowTestCount = $slowTestList->count();
+
+        if ($slowTestCount->equals(Count::fromInt(0))) {
+            return;
+        }
+
+        yield '';
+
+        yield '';
 
         if ($slowTestCount->equals(Count::fromInt(1))) {
             yield 'Detected 1 test where the duration exceeded the maximum duration.';
@@ -101,16 +113,16 @@ final class DefaultReporter implements Reporter
             ++$number;
         }
 
+        yield '';
+
         $additionalSlowTestCount = Count::fromInt(\max(
             0,
-            $slowTestList->count()->toInt() - $this->maximumCount->toCount()->toInt()
+            $slowTestCount->toInt() - $this->maximumCount->toCount()->toInt()
         ));
 
         if ($additionalSlowTestCount->equals(Count::fromInt(0))) {
             return;
         }
-
-        yield '';
 
         if ($additionalSlowTestCount->equals(Count::fromInt(1))) {
             yield 'There is 1 additional slow test that is not listed here.';
@@ -120,5 +132,7 @@ final class DefaultReporter implements Reporter
                 $additionalSlowTestCount->toInt()
             );
         }
+
+        yield '';
     }
 }

--- a/src/Subscriber/TestRunner/ExecutionFinishedSubscriber.php
+++ b/src/Subscriber/TestRunner/ExecutionFinishedSubscriber.php
@@ -57,6 +57,6 @@ final class ExecutionFinishedSubscriber implements Event\TestRunner\ExecutionFin
             return;
         }
 
-        echo "\n\n" . $report;
+        echo $report;
     }
 }

--- a/test/Unit/Reporter/DefaultReporterTest.php
+++ b/test/Unit/Reporter/DefaultReporterTest.php
@@ -83,12 +83,21 @@ final class DefaultReporterTest extends Framework\TestCase
      */
     public static function provideExpectedReportMaximumCountAndSlowTestList(): iterable
     {
+        $print = static function (array $lines): string {
+            return \implode('', \array_map(static function (string $line): string {
+                return $line . "\n";
+            }, $lines));
+        };
+
         $values = [
             'header-singular' => [
-                \implode("\n", [
+                $print([
+                    '',
+                    '',
                     'Detected 1 test where the duration exceeded the maximum duration.',
                     '',
                     '1. 00:00.300 (00:00.100) FooTest::test',
+                    '',
                 ]),
                 MaximumCount::fromCount(Count::fromInt(1)),
                 SlowTestList::create(
@@ -101,11 +110,14 @@ final class DefaultReporterTest extends Framework\TestCase
                 ),
             ],
             'header-plural' => [
-                \implode("\n", [
+                $print([
+                    '',
+                    '',
                     'Detected 2 tests where the duration exceeded the maximum duration.',
                     '',
                     '1. 00:00.300 (00:00.100) FooTest::test',
                     '2. 00:00.275 (00:00.100) BarTest::test',
+                    '',
                 ]),
                 MaximumCount::fromCount(Count::fromInt(2)),
                 SlowTestList::create(
@@ -124,12 +136,15 @@ final class DefaultReporterTest extends Framework\TestCase
                 ),
             ],
             'list-sorted' => [
-                \implode("\n", [
+                $print([
+                    '',
+                    '',
                     'Detected 3 tests where the duration exceeded the maximum duration.',
                     '',
                     '1. 00:00.300 (00:00.100) FooTest::test',
                     '2. 00:00.275 (00:00.100) BarTest::test',
                     '3. 00:00.250 (00:00.100) BazTest::test',
+                    '',
                 ]),
                 MaximumCount::fromCount(Count::fromInt(3)),
                 SlowTestList::create(
@@ -154,12 +169,15 @@ final class DefaultReporterTest extends Framework\TestCase
                 ),
             ],
             'list-unsorted' => [
-                \implode("\n", [
+                $print([
+                    '',
+                    '',
                     'Detected 3 tests where the duration exceeded the maximum duration.',
                     '',
                     '1. 00:00.300 (00:00.100) FooTest::test',
                     '2. 00:00.275 (00:00.100) BarTest::test',
                     '3. 00:00.250 (00:00.100) BazTest::test',
+                    '',
                 ]),
                 MaximumCount::fromCount(Count::fromInt(3)),
                 SlowTestList::create(
@@ -184,7 +202,9 @@ final class DefaultReporterTest extends Framework\TestCase
                 ),
             ],
             'list-different-maximum-duration' => [
-                \implode("\n", [
+                $print([
+                    '',
+                    '',
                     'Detected 10 tests where the duration exceeded the maximum duration.',
                     '',
                     ' 1. 20:50.000 (16:40.000) FooTest::test',
@@ -197,6 +217,7 @@ final class DefaultReporterTest extends Framework\TestCase
                     ' 8. 00:00.130 (00:00.100) GarplyTest::test',
                     ' 9. 00:00.120 (00:00.100) WaldoTest::test',
                     '10. 00:00.110 (00:00.100) FredTest::test',
+                    '',
                 ]),
                 MaximumCount::fromCount(Count::fromInt(10)),
                 SlowTestList::create(
@@ -263,12 +284,15 @@ final class DefaultReporterTest extends Framework\TestCase
                 ),
             ],
             'footer-singular' => [
-                \implode("\n", [
+                $print([
+                    '',
+                    '',
                     'Detected 2 tests where the duration exceeded the maximum duration.',
                     '',
                     '1. 00:00.300 (00:00.100) FooTest::test',
                     '',
                     'There is 1 additional slow test that is not listed here.',
+                    '',
                 ]),
                 MaximumCount::fromCount(Count::fromInt(1)),
                 SlowTestList::create(
@@ -287,12 +311,15 @@ final class DefaultReporterTest extends Framework\TestCase
                 ),
             ],
             'footer-plural' => [
-                \implode("\n", [
+                $print([
+                    '',
+                    '',
                     'Detected 3 tests where the duration exceeded the maximum duration.',
                     '',
                     '1. 00:00.300 (00:00.100) FooTest::test',
                     '',
                     'There are 2 additional slow tests that are not listed here.',
+                    '',
                 ]),
                 MaximumCount::fromCount(Count::fromInt(1)),
                 SlowTestList::create(


### PR DESCRIPTION
This pull request

- [x] pulls the printing of empty lines into the `DefaultReporter`

Related to #714.