### PR TITLE
Fix: Run unit tests on PHP 7.4 with `phpunit/phpunit:^7.5.0` only

### DIFF
--- a/.docker/tests-unit.sh
+++ b/.docker/tests-unit.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+cp --archive /app/src/. /app/work
+cd /app/work
+
+composer remove ergebnis/php-cs-fixer-config --ansi --dev --no-interaction --no-progress --quiet
+composer require phpunit/phpunit:^7.5.0 --ansi --no-interaction --no-progress --quiet --update-with-all-dependencies
+
+vendor/bin/phpunit --colors=always --configuration=test/Unit/phpunit.xml

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -806,7 +806,7 @@ jobs:
           dependencies: "${{ matrix.dependencies }}"
 
       - name: "Run unit tests with phpunit/phpunit:7.5.0"
-        if: "matrix.phpunit-version == '7.5.0'"
+        if: "matrix.php-version == '7.4' && matrix.phpunit-version == '7.5.0' && matrix.dependencies == 'highest'"
         run: "vendor/bin/phpunit --colors=always --configuration=test/Unit/phpunit.xml"
 
       - name: "Apply patch from https://github.com/sebastianbergmann/phpunit/pull/4486 for phpunit/phpunit:9.0.0"

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,8 @@ tests-phar: phar docker-build ## Runs phar tests with phpunit/phpunit in Docker 
 	docker run --rm --volume $(CURDIR):/app/src:ro --volume composer-cache:/root/.composer phpunit-slow-test-detector-php85 -c "/app/src/.docker/tests-phar.sh 13.0.0"
 
 .PHONY: tests-unit
-tests-unit: docker-build vendor ## Runs unit tests with phpunit/phpunit in a Docker container
-	docker run --rm --volume $(CURDIR):/app --volume composer-cache:/root/.composer phpunit-slow-test-detector-php74 -c "vendor/bin/phpunit --colors=always --configuration=test/Unit/phpunit.xml"
+tests-unit: docker-build ## Runs unit tests with phpunit/phpunit in a Docker container
+	docker run --rm --volume $(CURDIR):/app/src:ro --volume composer-cache:/root/.composer phpunit-slow-test-detector-php74 -c "/app/src/.docker/tests-unit.sh"
 
 vendor: docker-build composer.json composer.lock ## Installs dependencies with composer
 	docker run --rm --volume $(CURDIR):/app --volume composer-cache:/root/.composer phpunit-slow-test-detector-php74 -c "composer validate --ansi --strict"


### PR DESCRIPTION
This pull request

- [x] runs unit tests on PHP 7.4 with `phpunit/phpunit:^7.5.0` only

Fixes #710.