### PR TITLE
Fix: Send output to `STDERR` or `STDOUT` depending on configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.22.0...main`][2.22.0...main].
 
+### Fixed
+
+- Started sending output to `stderr` when PHPUnit is configured with `stderr="true"` in `phpunit.xml` for `phpunit/phpunit:^10.0.0`, `phpunit/phpunit:^11.0.0`, `phpunit/phpunit:^12.0.0`, `phpunit/phpunit:^13.0.0` ([#762]), by [@localheinz]
+
 ## [`2.22.0`][2.22.0]
 
 For a full diff see [`2.21.0...2.22.0`][2.21.0...2.22.0].
@@ -455,6 +459,7 @@ For a full diff see [`7afa59c...1.0.0`][7afa59c...1.0.0].
 [#713]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/713
 [#754]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/754
 [#757]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/757
+[#762]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/762
 
 [@courtney-miles]: https://github.com/courtney-miles
 [@dantleech]: https://github.com/dantleech

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -448,6 +448,18 @@ if ($phpUnitVersionSeries->major()->isOneOf(Version\Major::fromInt(10), Version\
                 $maximumCount
             );
 
+            $output = \fopen(
+                'php://stdout',
+                'wb'
+            );
+
+            if ($configuration->outputToStandardErrorStream()) {
+                $output = \fopen(
+                    'php://stderr',
+                    'wb'
+                );
+            }
+
             $facade->registerSubscribers(
                 new Subscriber\Test\PreparationStartedSubscriber($timeKeeper),
                 new Subscriber\Test\FinishedSubscriber(
@@ -458,7 +470,8 @@ if ($phpUnitVersionSeries->major()->isOneOf(Version\Major::fromInt(10), Version\
                 ),
                 new Subscriber\TestRunner\ExecutionFinishedSubscriber(
                     $collector,
-                    $reporter
+                    $reporter,
+                    $output
                 )
             );
         }

--- a/src/Subscriber/TestRunner/ExecutionFinishedSubscriber.php
+++ b/src/Subscriber/TestRunner/ExecutionFinishedSubscriber.php
@@ -32,12 +32,22 @@ final class ExecutionFinishedSubscriber implements Event\TestRunner\ExecutionFin
      */
     private $reporter;
 
+    /**
+     * @var resource
+     */
+    private $output;
+
+    /**
+     * @param resource $output
+     */
     public function __construct(
         Collector\Collector $collector,
-        Reporter\Reporter $reporter
+        Reporter\Reporter $reporter,
+        $output
     ) {
         $this->collector = $collector;
         $this->reporter = $reporter;
+        $this->output = $output;
     }
 
     /**
@@ -57,6 +67,9 @@ final class ExecutionFinishedSubscriber implements Event\TestRunner\ExecutionFin
             return;
         }
 
-        echo $report;
+        \fwrite(
+            $this->output,
+            $report
+        );
     }
 }

--- a/test/EndToEnd/PHPUnit10/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Configuration/Stderr/SleeperTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Configuration\Stderr;
+
+use Ergebnis\PHPUnit\SlowTestDetector\Test;
+use PHPUnit\Framework;
+
+#[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
+final class SleeperTest extends Framework\TestCase
+{
+    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    {
+        $milliseconds = 10;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
+    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    {
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    /**
+     * @return \Generator<int, array{0: int}>
+     */
+    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    {
+        $values = \range(
+            600,
+            1600,
+            100
+        );
+
+        foreach ($values as $value) {
+            yield $value => [
+                $value,
+            ];
+        }
+    }
+}

--- a/test/EndToEnd/PHPUnit10/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Configuration/Stderr/phpunit.xml
@@ -1,0 +1,33 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    requireCoverageMetadata="true"
+    stderr="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/PHPUnit10/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Configuration/Stderr/test.phpt
@@ -1,0 +1,37 @@
+--TEST--
+With configuration setting stderr to true
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/PHPUnit10/Configuration/Stderr/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+%a
+
+............                                                      12 / 12 (100%)
+
+Detected 11 tests where the duration exceeded the global maximum duration (00:00.500).
+
+ 1. 00:01.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
+ 2. 00:01.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
+ 3. 00:01.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
+ 4. 00:01.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
+ 5. 00:01.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
+ 6. 00:01.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
+ 7. 00:01.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
+ 8. 00:00.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
+ 9. 00:00.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
+10. 00:00.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
+
+There is 1 additional slow test that is not listed here.
+
+%a

--- a/test/EndToEnd/PHPUnit11/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Configuration/Stderr/SleeperTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Configuration\Stderr;
+
+use Ergebnis\PHPUnit\SlowTestDetector\Test;
+use PHPUnit\Framework;
+
+#[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
+final class SleeperTest extends Framework\TestCase
+{
+    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    {
+        $milliseconds = 10;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
+    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    {
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    /**
+     * @return \Generator<int, array{0: int}>
+     */
+    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    {
+        $values = \range(
+            600,
+            1600,
+            100
+        );
+
+        foreach ($values as $value) {
+            yield $value => [
+                $value,
+            ];
+        }
+    }
+}

--- a/test/EndToEnd/PHPUnit11/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Configuration/Stderr/phpunit.xml
@@ -1,0 +1,33 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    requireCoverageMetadata="true"
+    stderr="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/PHPUnit11/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Configuration/Stderr/test.phpt
@@ -1,0 +1,37 @@
+--TEST--
+With configuration setting stderr to true
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/PHPUnit11/Configuration/Stderr/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+%a
+
+............                                                      12 / 12 (100%)
+
+Detected 11 tests where the duration exceeded the global maximum duration (00:00.500).
+
+ 1. 00:01.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
+ 2. 00:01.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
+ 3. 00:01.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
+ 4. 00:01.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
+ 5. 00:01.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
+ 6. 00:01.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
+ 7. 00:01.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
+ 8. 00:00.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
+ 9. 00:00.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
+10. 00:00.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
+
+There is 1 additional slow test that is not listed here.
+
+%a

--- a/test/EndToEnd/PHPUnit12/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Configuration/Stderr/SleeperTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Configuration\Stderr;
+
+use Ergebnis\PHPUnit\SlowTestDetector\Test;
+use PHPUnit\Framework;
+
+#[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
+final class SleeperTest extends Framework\TestCase
+{
+    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    {
+        $milliseconds = 10;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
+    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    {
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    /**
+     * @return \Generator<int, array{0: int}>
+     */
+    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    {
+        $values = \range(
+            600,
+            1600,
+            100
+        );
+
+        foreach ($values as $value) {
+            yield $value => [
+                $value,
+            ];
+        }
+    }
+}

--- a/test/EndToEnd/PHPUnit12/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Configuration/Stderr/phpunit.xml
@@ -1,0 +1,33 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    requireCoverageMetadata="true"
+    stderr="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/PHPUnit12/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Configuration/Stderr/test.phpt
@@ -1,0 +1,37 @@
+--TEST--
+With configuration setting stderr to true
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/PHPUnit12/Configuration/Stderr/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+%a
+
+............                                                      12 / 12 (100%)
+
+Detected 11 tests where the duration exceeded the global maximum duration (00:00.500).
+
+ 1. 00:01.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1600)
+ 2. 00:01.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1500)
+ 3. 00:01.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1400)
+ 4. 00:01.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1300)
+ 5. 00:01.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1200)
+ 6. 00:01.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1100)
+ 7. 00:01.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1000)
+ 8. 00:00.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(900)
+ 9. 00:00.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(800)
+10. 00:00.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(700)
+
+There is 1 additional slow test that is not listed here.
+
+%a

--- a/test/EndToEnd/PHPUnit13/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Configuration/Stderr/SleeperTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2021-2026 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpunit-slow-test-detector
+ */
+
+namespace Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Configuration\Stderr;
+
+use Ergebnis\PHPUnit\SlowTestDetector\Test;
+use PHPUnit\Framework;
+
+#[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
+final class SleeperTest extends Framework\TestCase
+{
+    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    {
+        $milliseconds = 10;
+
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
+    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    {
+        $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
+
+        $sleeper->sleep();
+
+        self::assertSame($milliseconds, $sleeper->milliseconds());
+    }
+
+    /**
+     * @return \Generator<int, array{0: int}>
+     */
+    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    {
+        $values = \range(
+            600,
+            1600,
+            100
+        );
+
+        foreach ($values as $value) {
+            yield $value => [
+                $value,
+            ];
+        }
+    }
+}

--- a/test/EndToEnd/PHPUnit13/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Configuration/Stderr/phpunit.xml
@@ -1,0 +1,33 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.0/phpunit.xsd"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="../../../../../vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    columns="max"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    executionOrder="default"
+    requireCoverageMetadata="true"
+    stderr="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+>
+    <extensions>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+    </extensions>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/EndToEnd/PHPUnit13/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Configuration/Stderr/test.phpt
@@ -1,0 +1,37 @@
+--TEST--
+With configuration setting stderr to true
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\TextUI;
+
+$_SERVER['argv'][] = '--configuration=test/EndToEnd/PHPUnit13/Configuration/Stderr/phpunit.xml';
+
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
+
+$application = new TextUI\Application();
+
+$application->run($_SERVER['argv']);
+--EXPECTF--
+%a
+
+............                                                      12 / 12 (100%)
+
+Detected 11 tests where the duration exceeded the global maximum duration (00:00.500).
+
+ 1. 00:01.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1600)
+ 2. 00:01.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1500)
+ 3. 00:01.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1400)
+ 4. 00:01.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1300)
+ 5. 00:01.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1200)
+ 6. 00:01.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1100)
+ 7. 00:01.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1000)
+ 8. 00:00.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(900)
+ 9. 00:00.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(800)
+10. 00:00.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(700)
+
+There is 1 additional slow test that is not listed here.
+
+%a


### PR DESCRIPTION
This pull request

- [x] sends the output to `STDERR` or `STDOUT` depending on the configuration

Fixes #688.