### PR TITLE
Fix: Rename `DefaultReporter` to `ConsoleReporter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.23.0...main`][2.23.0...main].
 
+### Fixed
+
+- Renamed `DefaultReporter` to `ConsoleReporter` ([#774]), by [@localheinz]
+
 ## [`2.23.0`][2.23.0]
 
 For a full diff see [`2.22.2...2.23.0`][2.22.2...2.23.0].
@@ -490,6 +494,7 @@ For a full diff see [`7afa59c...1.0.0`][7afa59c...1.0.0].
 [#765]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/765
 [#768]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/768
 [#773]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/773
+[#774]: https://github.com/ergebnis/phpunit-slow-test-detector/pull/774
 
 [@courtney-miles]: https://github.com/courtney-miles
 [@dantleech]: https://github.com/dantleech

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -341,14 +341,14 @@ parameters:
 			path: test/Unit/Reporter/ColorTest.php
 
 		-
-			message: "#^Method Ergebnis\\\\PHPUnit\\\\SlowTestDetector\\\\Test\\\\Unit\\\\Reporter\\\\DefaultReporterTest\\:\\:testReportReturnsEmptyStringWhenSlowTestListIsEmpty\\(\\) has no return type specified\\.$#"
+			message: "#^Method Ergebnis\\\\PHPUnit\\\\SlowTestDetector\\\\Test\\\\Unit\\\\Reporter\\\\ConsoleReporterTest\\:\\:testReportReturnsEmptyStringWhenSlowTestListIsEmpty\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: test/Unit/Reporter/DefaultReporterTest.php
+			path: test/Unit/Reporter/ConsoleReporterTest.php
 
 		-
-			message: "#^Method Ergebnis\\\\PHPUnit\\\\SlowTestDetector\\\\Test\\\\Unit\\\\Reporter\\\\DefaultReporterTest\\:\\:testReportReturnsReportWhenSlowTestListHasFewerSlowTestsThanMaximumCount\\(\\) has no return type specified\\.$#"
+			message: "#^Method Ergebnis\\\\PHPUnit\\\\SlowTestDetector\\\\Test\\\\Unit\\\\Reporter\\\\ConsoleReporterTest\\:\\:testReportReturnsReportWhenSlowTestListHasFewerSlowTestsThanMaximumCount\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: test/Unit/Reporter/DefaultReporterTest.php
+			path: test/Unit/Reporter/ConsoleReporterTest.php
 
 		-
 			message: "#^Method Ergebnis\\\\PHPUnit\\\\SlowTestDetector\\\\Test\\\\Unit\\\\Reporter\\\\Formatter\\\\DefaultDurationFormatterTest\\:\\:testFormatFormats\\(\\) has no return type specified\\.$#"

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -67,7 +67,7 @@ if ($phpUnitVersionSeries->major()->equals(Version\Major::fromInt(6))) {
 
             $this->maximumDuration = $maximumDuration;
             $this->collector = new Collector\DefaultCollector();
-            $this->reporter = new Reporter\DefaultReporter(
+            $this->reporter = new Reporter\ConsoleReporter(
                 new Reporter\Formatter\DefaultDurationFormatter(),
                 $maximumDuration,
                 $maximumCount
@@ -271,7 +271,7 @@ if ($phpUnitVersionSeries->major()->isOneOf(Version\Major::fromInt(7), Version\M
 
             $this->maximumDuration = $maximumDuration;
             $this->collector = new Collector\DefaultCollector();
-            $this->reporter = new Reporter\DefaultReporter(
+            $this->reporter = new Reporter\ConsoleReporter(
                 new Reporter\Formatter\DefaultDurationFormatter(),
                 $maximumDuration,
                 $maximumCount
@@ -442,7 +442,7 @@ if ($phpUnitVersionSeries->major()->isOneOf(Version\Major::fromInt(10), Version\
 
             $timeKeeper = new TimeKeeper();
             $collector = new Collector\DefaultCollector();
-            $reporter = new Reporter\DefaultReporter(
+            $reporter = new Reporter\ConsoleReporter(
                 new Reporter\Formatter\DefaultDurationFormatter(),
                 $maximumDuration,
                 $maximumCount

--- a/src/Reporter/ConsoleReporter.php
+++ b/src/Reporter/ConsoleReporter.php
@@ -23,7 +23,7 @@ use Ergebnis\PHPUnit\SlowTestDetector\SlowTestList;
 /**
  * @internal
  */
-final class DefaultReporter implements Reporter
+final class ConsoleReporter implements Reporter
 {
     /**
      * @var Formatter\DurationFormatter

--- a/test/Unit/Reporter/ConsoleReporterTest.php
+++ b/test/Unit/Reporter/ConsoleReporterTest.php
@@ -26,7 +26,7 @@ use Ergebnis\PHPUnit\SlowTestDetector\TestIdentifier;
 use PHPUnit\Framework;
 
 /**
- * @covers \Ergebnis\PHPUnit\SlowTestDetector\Reporter\DefaultReporter
+ * @covers \Ergebnis\PHPUnit\SlowTestDetector\Reporter\ConsoleReporter
  *
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\Comparator\DurationComparator
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\Count
@@ -40,7 +40,7 @@ use PHPUnit\Framework;
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\TestDescription
  * @uses \Ergebnis\PHPUnit\SlowTestDetector\TestIdentifier
  */
-final class DefaultReporterTest extends Framework\TestCase
+final class ConsoleReporterTest extends Framework\TestCase
 {
     use Test\Util\Helper;
 
@@ -50,7 +50,7 @@ final class DefaultReporterTest extends Framework\TestCase
 
         $slowTestList = SlowTestList::create();
 
-        $reporter = new Reporter\DefaultReporter(
+        $reporter = new Reporter\ConsoleReporter(
             new Reporter\Formatter\DefaultDurationFormatter(),
             MaximumDuration::default(),
             MaximumCount::fromCount(Count::fromInt($faker->numberBetween(1)))
@@ -70,7 +70,7 @@ final class DefaultReporterTest extends Framework\TestCase
         MaximumCount $maximumCount,
         SlowTestList $slowTestList
     ) {
-        $reporter = new Reporter\DefaultReporter(
+        $reporter = new Reporter\ConsoleReporter(
             new Reporter\Formatter\DefaultDurationFormatter(),
             $maximumDuration,
             $maximumCount


### PR DESCRIPTION
This pull request

- [x] renames `DefaultReporter` to `ConsoleReporter`

Related to #712.