### PR TITLE
Fix: Adjust maximum duration in tests to reduce pain of running tests

### DIFF
--- a/test/EndToEnd/PHPUnit06/Console/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/Defaults/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): \Generator
     {
         $values = \range(
-            600,
-            1600,
-            100
+            550,
+            1050,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/Defaults/test.phpt
@@ -21,16 +21,16 @@ Detected 11 tests where the duration exceeded the global maximum duration (0.500
 
  # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumCount/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration()
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration()
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds)
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds)
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): \Generator
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumCount/phpunit.xml
@@ -22,6 +22,9 @@
                     <element key="maximum-count">
                         <integer>3</integer>
                     </element>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                 </array>
             </arguments>
         </listener>

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumCount/test.phpt
@@ -17,14 +17,14 @@ PHPUnit\TextUI\Command::main();
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds
 

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumDuration/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
-            200,
-            1200,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumDuration/test.phpt
@@ -21,16 +21,16 @@ Detected 11 tests where the duration exceeded the global maximum duration (0.100
 
  # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10
- 2    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9
- 3    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8
- 4    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7
- 5    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6
- 6    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5
- 7    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4
- 8    0.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3
- 9    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2
-10    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumWidth/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumWidth/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration()
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration()
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds)
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds)
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): \Generator
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumWidth/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumWidth/phpunit.xml
@@ -19,6 +19,9 @@
         <listener class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <arguments>
                 <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                     <element key="maximum-width">
                         <integer>100</integer>
                     </element>

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumWidth/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumWidth/test.phpt
@@ -17,15 +17,15 @@ PHPUnit\TextUI\Command::main();
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…mumDurationWithDataProvider with data set #4
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…mumDurationWithDataProvider with data set #3
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…mumDurationWithDataProvider with data set #2
-4    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…mumDurationWithDataProvider with data set #1
-5    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…mumDurationWithDataProvider with data set #0
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…nfigurationWithDataProvider with data set #4
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…nfigurationWithDataProvider with data set #3
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…nfigurationWithDataProvider with data set #2
+4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…nfigurationWithDataProvider with data set #1
+5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…nfigurationWithDataProvider with data set #0
 ----------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/Stderr/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration()
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration()
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds)
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds)
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): \Generator
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
-            600,
-            1600,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/Stderr/phpunit.xml
@@ -20,6 +20,9 @@
         <listener class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <arguments>
                 <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                     <element key="stderr">
                         <boolean>true</boolean>
                     </element>

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/Stderr/test.phpt
@@ -17,21 +17,21 @@ PHPUnit\TextUI\Command::main();
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests where the duration exceeded the global maximum duration (0.500).
+Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds
 

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/Bare/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/Bare/test.phpt
@@ -19,8 +19,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/Combination/SleeperTest.php
@@ -112,9 +112,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/Combination/test.phpt
@@ -20,8 +20,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterClassAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterClassAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPostConditions/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPreConditions/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeClassAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithDataProvider/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithDataProvider/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithDataProvider/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUp/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUp/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUpBeforeClass/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDown/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDown/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): \Generator
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDownAfterClass/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit06\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/Defaults/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            550,
+            1050,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/Defaults/test.phpt
@@ -21,16 +21,16 @@ Detected 11 tests where the duration exceeded the global maximum duration (0.500
 
  # Duration Test
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1050)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1000)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (950)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (900)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (850)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (800)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (750)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (700)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (650)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (600)
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumCount/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumCount/phpunit.xml
@@ -22,6 +22,9 @@
                     <element key="maximum-count">
                         <integer>3</integer>
                     </element>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                 </array>
             </arguments>
         </extension>

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumCount/test.phpt
@@ -17,14 +17,14 @@ PHPUnit\TextUI\Command::main();
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds
 

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumDuration/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            200,
-            1200,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumDuration/test.phpt
@@ -20,18 +20,18 @@ PHPUnit\TextUI\Command::main();
 Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (1200)
- 2    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (1100)
- 3    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (1000)
- 4    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (900)
- 5    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (800)
- 6    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (700)
- 7    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (600)
- 8    0.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (500)
- 9    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (400)
-10    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds
 

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumWidth/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumWidth/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumWidth/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumWidth/phpunit.xml
@@ -19,6 +19,9 @@
         <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <arguments>
                 <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                     <element key="maximum-width">
                         <integer>100</integer>
                     </element>

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumWidth/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumWidth/test.phpt
@@ -17,15 +17,15 @@ PHPUnit\TextUI\Command::main();
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…tionWithDataProvider with data set #4 (1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #3 (900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #2 (800)
-4    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #1 (700)
-5    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #0 (600)
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #4 (350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #3 (300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #2 (250)
+4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #1 (200)
+5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #0 (150)
 ----------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/Stderr/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/Stderr/phpunit.xml
@@ -20,6 +20,9 @@
         <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <arguments>
                 <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                     <element key="stderr">
                         <boolean>true</boolean>
                     </element>

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/Stderr/test.phpt
@@ -17,21 +17,21 @@ PHPUnit\TextUI\Command::main();
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests where the duration exceeded the global maximum duration (0.500).
+Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds
 

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/Bare/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/Bare/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/Combination/SleeperTest.php
@@ -112,9 +112,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/Combination/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterClassAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterClassAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPostConditions/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPreConditions/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeClassAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithDataProvider/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithDataProvider/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithDataProvider/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUp/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUp/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUpBeforeClass/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDown/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDown/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDownAfterClass/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit07\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/Defaults/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            550,
+            1050,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/Defaults/test.phpt
@@ -21,16 +21,16 @@ Detected 11 tests where the duration exceeded the global maximum duration (0.500
 
  # Duration Test
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1050)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1000)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (950)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (900)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (850)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (800)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (750)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (700)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (650)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (600)
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumCount/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumCount/phpunit.xml
@@ -24,6 +24,9 @@
                     <element key="maximum-count">
                         <integer>3</integer>
                     </element>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                 </array>
             </arguments>
         </extension>

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumCount/test.phpt
@@ -17,14 +17,14 @@ PHPUnit\TextUI\Command::main();
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds
 

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumDuration/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            200,
-            1200,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumDuration/test.phpt
@@ -20,18 +20,18 @@ PHPUnit\TextUI\Command::main();
 Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (1200)
- 2    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (1100)
- 3    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (1000)
- 4    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (900)
- 5    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (800)
- 6    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (700)
- 7    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (600)
- 8    0.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (500)
- 9    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (400)
-10    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds
 

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumWidth/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumWidth/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumWidth/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumWidth/phpunit.xml
@@ -21,6 +21,9 @@
         <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <arguments>
                 <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                     <element key="maximum-width">
                         <integer>100</integer>
                     </element>

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumWidth/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumWidth/test.phpt
@@ -17,15 +17,15 @@ PHPUnit\TextUI\Command::main();
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…tionWithDataProvider with data set #4 (1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #3 (900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #2 (800)
-4    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #1 (700)
-5    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #0 (600)
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #4 (350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #3 (300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #2 (250)
+4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #1 (200)
+5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #0 (150)
 ----------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/Stderr/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/Stderr/phpunit.xml
@@ -22,6 +22,9 @@
         <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <arguments>
                 <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                     <element key="stderr">
                         <boolean>true</boolean>
                     </element>

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/Stderr/test.phpt
@@ -17,21 +17,21 @@ PHPUnit\TextUI\Command::main();
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests where the duration exceeded the global maximum duration (0.500).
+Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds
 

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/Bare/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/Bare/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/Combination/SleeperTest.php
@@ -112,9 +112,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/Combination/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterClassAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterClassAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPostConditions/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPreConditions/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeClassAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithDataProvider/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithDataProvider/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithDataProvider/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUp/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUp/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUpBeforeClass/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDown/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDown/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDownAfterClass/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit08\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/Defaults/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            550,
+            1050,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/Defaults/test.phpt
@@ -21,16 +21,16 @@ Detected 11 tests where the duration exceeded the global maximum duration (0.500
 
  # Duration Test
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1050)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1000)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (950)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (900)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (850)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (800)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (750)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (700)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (650)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (600)
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumCount/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumCount/phpunit.xml
@@ -24,6 +24,9 @@
                     <element key="maximum-count">
                         <integer>3</integer>
                     </element>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                 </array>
             </arguments>
         </extension>

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumCount/test.phpt
@@ -17,14 +17,14 @@ PHPUnit\TextUI\Command::main();
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds
 

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumDuration/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            200,
-            1200,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumDuration/test.phpt
@@ -20,18 +20,18 @@ PHPUnit\TextUI\Command::main();
 Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (1200)
- 2    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (1100)
- 3    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (1000)
- 4    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (900)
- 5    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (800)
- 6    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (700)
- 7    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (600)
- 8    0.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (500)
- 9    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (400)
-10    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds
 

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumWidth/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumWidth/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumWidth/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumWidth/phpunit.xml
@@ -21,6 +21,9 @@
         <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <arguments>
                 <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                     <element key="maximum-width">
                         <integer>100</integer>
                     </element>

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumWidth/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumWidth/test.phpt
@@ -17,15 +17,15 @@ PHPUnit\TextUI\Command::main();
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…tionWithDataProvider with data set #4 (1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #3 (900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #2 (800)
-4    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #1 (700)
-5    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #0 (600)
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #4 (350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #3 (300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #2 (250)
+4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #1 (200)
+5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #0 (150)
 ----------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/Stderr/SleeperTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework;
  */
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -33,9 +33,9 @@ final class SleeperTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider provideMillisecondsGreaterThanDefaultMaximumDuration
+     * @dataProvider provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration
      */
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -47,12 +47,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/Stderr/phpunit.xml
@@ -22,6 +22,9 @@
         <extension class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <arguments>
                 <array>
+                    <element key="maximum-duration">
+                        <integer>100</integer>
+                    </element>
                     <element key="stderr">
                         <boolean>true</boolean>
                     </element>

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/Stderr/test.phpt
@@ -17,21 +17,21 @@ PHPUnit\TextUI\Command::main();
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests where the duration exceeded the global maximum duration (0.500).
+Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds
 

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/Bare/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/Bare/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/Combination/SleeperTest.php
@@ -112,9 +112,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/Combination/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterClassAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterClassAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPostConditions/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPreConditions/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeClassAnnotation/SleeperTest.php
@@ -58,9 +58,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithDataProvider/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithDataProvider/SleeperTest.php
@@ -50,9 +50,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithDataProvider/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUp/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUp/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUpBeforeClass/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDown/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDown/test.phpt
@@ -21,8 +21,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -55,9 +55,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDownAfterClass/test.phpt
@@ -21,8 +21,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit09\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/Defaults/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            550,
+            1050,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/Defaults/test.phpt
@@ -23,16 +23,16 @@ Detected 11 tests where the duration exceeded the global maximum duration (0.500
 
  # Duration Test
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1050)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1000)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (950)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (900)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (850)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (800)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (750)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (700)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (650)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (600)
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumCount/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumCount/phpunit.xml
@@ -24,6 +24,7 @@
     <extensions>
         <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <parameter name="maximum-count" value="3"/>
+            <parameter name="maximum-duration" value="100"/>
         </bootstrap>
     </extensions>
     <testsuites>

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumCount/test.phpt
@@ -19,14 +19,14 @@ $application->run($_SERVER['argv']);
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds
 

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumDuration/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            200,
-            1200,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumDuration/test.phpt
@@ -22,18 +22,18 @@ $application->run($_SERVER['argv']);
 Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (1200)
- 2    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (1100)
- 3    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (1000)
- 4    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (900)
- 5    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (800)
- 6    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (700)
- 7    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (600)
- 8    0.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (500)
- 9    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (400)
-10    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds
 

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumWidth/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumWidth/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumWidth/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumWidth/phpunit.xml
@@ -23,6 +23,7 @@
 >
     <extensions>
         <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
             <parameter name="maximum-width" value="100"/>
         </bootstrap>
     </extensions>

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumWidth/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumWidth/test.phpt
@@ -19,15 +19,15 @@ $application->run($_SERVER['argv']);
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…tionWithDataProvider with data set #4 (1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #3 (900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #2 (800)
-4    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #1 (700)
-5    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #0 (600)
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #4 (350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #3 (300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #2 (250)
+4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #1 (200)
+5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #0 (150)
 ----------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/Stderr/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/Stderr/phpunit.xml
@@ -23,7 +23,9 @@
     stopOnSkipped="false"
 >
     <extensions>
-        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
     </extensions>
     <testsuites>
         <testsuite name="Unit Tests">

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/Stderr/test.phpt
@@ -19,21 +19,21 @@ $application->run($_SERVER['argv']);
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests where the duration exceeded the global maximum duration (0.500).
+Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds
 

--- a/test/EndToEnd/PHPUnit10/Console/Option/NoOutput/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/Option/NoOutput/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 200;
+        $milliseconds = 150;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/Bare/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/Bare/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/Combination/SleeperTest.php
@@ -132,9 +132,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/Combination/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    1.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    1.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    1.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAnnotation/SleeperTest.php
@@ -54,9 +54,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAnnotation/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAnnotation/SleeperTest.php
@@ -54,9 +54,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAnnotation/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPostConditions/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPreConditions/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAnnotation/SleeperTest.php
@@ -54,9 +54,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAnnotation/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeAnnotation\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAnnotation/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAnnotation/SleeperTest.php
@@ -54,9 +54,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAnnotation/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAnnotation/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeClassAnnotation\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithDataProvider/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithDataProvider/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithDataProvider/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUp/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUp/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUpBeforeClass/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDown/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDown/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDownAfterClass/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit10\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/Defaults/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            550,
+            1050,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/Defaults/test.phpt
@@ -23,16 +23,16 @@ Detected 11 tests where the duration exceeded the global maximum duration (0.500
 
  # Duration Test
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1050)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1000)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (950)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (900)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (850)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (800)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (750)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (700)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (650)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (600)
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumCount/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumCount/phpunit.xml
@@ -24,6 +24,7 @@
     <extensions>
         <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <parameter name="maximum-count" value="3"/>
+            <parameter name="maximum-duration" value="100"/>
         </bootstrap>
     </extensions>
     <testsuites>

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumCount/test.phpt
@@ -19,14 +19,14 @@ $application->run($_SERVER['argv']);
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds
 

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumDuration/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            200,
-            1200,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumDuration/test.phpt
@@ -22,18 +22,18 @@ $application->run($_SERVER['argv']);
 Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (1200)
- 2    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (1100)
- 3    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (1000)
- 4    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (900)
- 5    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (800)
- 6    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (700)
- 7    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (600)
- 8    0.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (500)
- 9    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (400)
-10    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds
 

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumWidth/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumWidth/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumWidth/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumWidth/phpunit.xml
@@ -23,6 +23,7 @@
 >
     <extensions>
         <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
             <parameter name="maximum-width" value="100"/>
         </bootstrap>
     </extensions>

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumWidth/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumWidth/test.phpt
@@ -19,15 +19,15 @@ $application->run($_SERVER['argv']);
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…tionWithDataProvider with data set #4 (1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #3 (900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #2 (800)
-4    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #1 (700)
-5    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #0 (600)
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #4 (350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #3 (300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #2 (250)
+4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #1 (200)
+5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…ationWithDataProvider with data set #0 (150)
 ----------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/Stderr/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/Stderr/phpunit.xml
@@ -23,7 +23,9 @@
     stopOnSkipped="false"
 >
     <extensions>
-        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
     </extensions>
     <testsuites>
         <testsuite name="Unit Tests">

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/Stderr/test.phpt
@@ -19,21 +19,21 @@ $application->run($_SERVER['argv']);
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests where the duration exceeded the global maximum duration (0.500).
+Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #10 (1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #9 (1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #8 (1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #7 (1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #6 (1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #5 (1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #4 (1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #3 (900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #2 (800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider with data set #1 (700)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #10 (650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #9 (600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #8 (550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #7 (500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #6 (450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #5 (400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #4 (350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #3 (300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #2 (250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0.000
        └─── seconds
 

--- a/test/EndToEnd/PHPUnit11/Console/Option/NoOutput/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/Option/NoOutput/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 200;
+        $milliseconds = 150;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/Bare/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/Bare/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/Combination/SleeperTest.php
@@ -100,9 +100,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/Combination/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterClassAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterClassAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterClassAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterClassAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPostConditions/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPreConditions/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeClassAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeClassAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeClassAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeClassAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithDataProvider/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithDataProvider/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithDataProvider/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUp/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUp/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUpBeforeClass/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDown/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDown/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDownAfterClass/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #1 (200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit11\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider with data set #0 (150)
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/Defaults/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            550,
+            1050,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/Defaults/test.phpt
@@ -23,16 +23,16 @@ Detected 11 tests where the duration exceeded the global maximum duration (0.500
 
  # Duration Test
 ---------%s
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(700)
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1050)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1000)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(950)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(900)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(850)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(800)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(750)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(700)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(650)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(600)
 ---------%s
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumCount/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumCount/phpunit.xml
@@ -24,6 +24,7 @@
     <extensions>
         <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <parameter name="maximum-count" value="3"/>
+            <parameter name="maximum-duration" value="100"/>
         </bootstrap>
     </extensions>
     <testsuites>

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumCount/test.phpt
@@ -19,13 +19,13 @@ $application->run($_SERVER['argv']);
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
 ---------%s
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(800)
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(250)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumDuration/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            200,
-            1200,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumDuration/test.phpt
@@ -23,16 +23,16 @@ Detected 11 tests where the duration exceeded the global maximum duration (0.100
 
  # Duration Test
 ---------%s
- 1    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(1200)
- 2    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(1100)
- 3    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(1000)
- 4    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(900)
- 5    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(800)
- 6    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(700)
- 7    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(600)
- 8    0.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(500)
- 9    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(400)
-10    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
 ---------%s
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumWidth/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumWidth/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumWidth/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumWidth/phpunit.xml
@@ -23,6 +23,7 @@
 >
     <extensions>
         <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
             <parameter name="maximum-width" value="100"/>
         </bootstrap>
     </extensions>

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumWidth/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumWidth/test.phpt
@@ -19,15 +19,15 @@ $application->run($_SERVER['argv']);
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(800)
-4    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(700)
-5    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(600)
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(250)
+4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(200)
+5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(150)
 ----------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/Stderr/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/Stderr/phpunit.xml
@@ -23,7 +23,9 @@
     stopOnSkipped="false"
 >
     <extensions>
-        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
     </extensions>
     <testsuites>
         <testsuite name="Unit Tests">

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/Stderr/test.phpt
@@ -19,20 +19,20 @@ $application->run($_SERVER['argv']);
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests where the duration exceeded the global maximum duration (0.500).
+Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
 ---------%s
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(700)
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
 ---------%s
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit12/Console/Option/NoOutput/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/Option/NoOutput/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 200;
+        $milliseconds = 150;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/Bare/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/Bare/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/Combination/SleeperTest.php
@@ -100,9 +100,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/Combination/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterClassAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterClassAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterClassAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterClassAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPostConditions/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPreConditions/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeClassAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeClassAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeClassAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeClassAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithDataProvider/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithDataProvider/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithDataProvider/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUp/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUp/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUpBeforeClass/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDown/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDown/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDownAfterClass/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit12\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/Defaults/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/Defaults/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            550,
+            1050,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/Defaults/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/Defaults/test.phpt
@@ -23,16 +23,16 @@ Detected 11 tests where the duration exceeded the global maximum duration (0.500
 
  # Duration Test
 ---------%s
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(700)
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1050)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1000)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(950)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(900)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(850)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(800)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(750)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(700)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(650)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Defaults\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(600)
 ---------%s
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumCount/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumCount/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumCount/phpunit.xml
@@ -24,6 +24,7 @@
     <extensions>
         <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
             <parameter name="maximum-count" value="3"/>
+            <parameter name="maximum-duration" value="100"/>
         </bootstrap>
     </extensions>
     <testsuites>

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumCount/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumCount/test.phpt
@@ -19,13 +19,13 @@ $application->run($_SERVER['argv']);
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
 ---------%s
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(800)
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumCount\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(250)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumDuration/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumDuration/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            200,
-            1200,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumDuration/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumDuration/test.phpt
@@ -23,16 +23,16 @@ Detected 11 tests where the duration exceeded the global maximum duration (0.100
 
  # Duration Test
 ---------%s
- 1    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(1200)
- 2    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(1100)
- 3    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(1000)
- 4    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(900)
- 5    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(800)
- 6    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(700)
- 7    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(600)
- 8    0.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(500)
- 9    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(400)
-10    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\MaximumDuration\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
 ---------%s
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumWidth/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumWidth/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1000,
-            100
+            150,
+            350,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumWidth/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumWidth/phpunit.xml
@@ -23,6 +23,7 @@
 >
     <extensions>
         <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
             <parameter name="maximum-width" value="100"/>
         </bootstrap>
     </extensions>

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumWidth/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumWidth/test.phpt
@@ -19,15 +19,15 @@ $application->run($_SERVER['argv']);
 
 ......                                                              6 / 6 (100%)
 
-Detected 5 tests where the duration exceeded the global maximum duration (0.500).
+Detected 5 tests where the duration exceeded the global maximum duration (0.100).
 
 # Duration Test
 ----------------------------------------------------------------------------------------------------
-1    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(1000)
-2    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(900)
-3    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(800)
-4    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(700)
-5    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(600)
+1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(350)
+2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(300)
+3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(250)
+4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(200)
+5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndTo…%s(150)
 ----------------------------------------------------------------------------------------------------
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/Stderr/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/Stderr/SleeperTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Test\Fixture\Sleeper::class)]
 final class SleeperTest extends Framework\TestCase
 {
-    public function testSleeperSleepsLessThanDefaultMaximumDuration(): void
+    public function testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration(): void
     {
         $milliseconds = 10;
 
@@ -30,8 +30,8 @@ final class SleeperTest extends Framework\TestCase
         self::assertSame($milliseconds, $sleeper->milliseconds());
     }
 
-    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanDefaultMaximumDuration')]
-    public function testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider(int $milliseconds): void
+    #[Framework\Attributes\DataProvider('provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration')]
+    public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider(int $milliseconds): void
     {
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 
@@ -43,12 +43,12 @@ final class SleeperTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public static function provideMillisecondsGreaterThanDefaultMaximumDuration(): iterable
+    public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
-            600,
-            1600,
-            100
+            150,
+            650,
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/Stderr/phpunit.xml
@@ -23,7 +23,9 @@
     stopOnSkipped="false"
 >
     <extensions>
-        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>
+        <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension">
+            <parameter name="maximum-duration" value="100"/>
+        </bootstrap>
     </extensions>
     <testsuites>
         <testsuite name="Unit Tests">

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/Stderr/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/Stderr/test.phpt
@@ -19,20 +19,20 @@ $application->run($_SERVER['argv']);
 
 ............                                                      12 / 12 (100%)
 
-Detected 11 tests where the duration exceeded the global maximum duration (0.500).
+Detected 11 tests where the duration exceeded the global maximum duration (0.100).
 
  # Duration Test
 ---------%s
- 1    1.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1600)
- 2    1.5%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1500)
- 3    1.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1400)
- 4    1.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1300)
- 5    1.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1200)
- 6    1.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1100)
- 7    1.0%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(1000)
- 8    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(900)
- 9    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(800)
-10    0.7%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanDefaultMaximumDurationWithDataProvider%s(700)
+ 1    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(650)
+ 2    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(600)
+ 3    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(550)
+ 4    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(500)
+ 5    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(450)
+ 6    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(400)
+ 7    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(350)
+ 8    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
+ 9    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(250)
+10    %s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\Configuration\Stderr\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
 ---------%s
       0.000
        └─── seconds

--- a/test/EndToEnd/PHPUnit13/Console/Option/NoOutput/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/Option/NoOutput/SleeperTest.php
@@ -21,7 +21,7 @@ final class SleeperTest extends Framework\TestCase
 {
     public function testSleeperSleepsLongerThanMaximumDurationFromXmlConfiguration(): void
     {
-        $milliseconds = 200;
+        $milliseconds = 150;
 
         $sleeper = Test\Fixture\Sleeper::fromMilliseconds($milliseconds);
 

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/Bare/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/Bare/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/Bare/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/Bare/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\Bare\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/Combination/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/Combination/SleeperTest.php
@@ -100,9 +100,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/Combination/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/Combination/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.9%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.8%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.6%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\Combination\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAfterAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterClassAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterClassAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterClassAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterClassAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAfterClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPostConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPostConditions/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPostConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPostConditions/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAssertPostConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPreConditions/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPreConditions/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPreConditions/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPreConditions/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithAssertPreConditions\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithBeforeAttribute\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeClassAttribute/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeClassAttribute/SleeperTest.php
@@ -52,9 +52,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeClassAttribute/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeClassAttribute/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithBeforeClassAttribute\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithDataProvider/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithDataProvider/SleeperTest.php
@@ -46,9 +46,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithDataProvider/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithDataProvider/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithDataProvider\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUp/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUp/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUp/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUp/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithSetUp\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUpBeforeClass/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUpBeforeClass/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUpBeforeClass/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithSetUpBeforeClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDown/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDown/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDown/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDown/test.phpt
@@ -23,8 +23,8 @@ Detected 3 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.4%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 3    0.1%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithTearDown\SleeperTest::testSleeperSleepsLessThanMaximumDurationFromXmlConfiguration
 ---------%s
      0.000

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDownAfterClass/SleeperTest.php
@@ -51,9 +51,9 @@ final class SleeperTest extends Framework\TestCase
     public static function provideMillisecondsGreaterThanMaximumDurationFromXmlConfiguration(): iterable
     {
         $values = \range(
+            150,
             200,
-            300,
-            100
+            50
         );
 
         foreach ($values as $value) {

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDownAfterClass/test.phpt
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDownAfterClass/test.phpt
@@ -23,8 +23,8 @@ Detected 2 tests where the duration exceeded the global maximum duration (0.100)
 
 # Duration Test
 ---------%s
-1    0.3%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(300)
-2    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+1    0.2%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(200)
+2    0.%s Ergebnis\PHPUnit\SlowTestDetector\Test\EndToEnd\PHPUnit13\Console\TestCase\WithTearDownAfterClass\SleeperTest::testSleeperSleepsLongerThanMaximumDurationFromXmlConfigurationWithDataProvider%s(150)
 ---------%s
      0.000
       └─── seconds


### PR DESCRIPTION
This pull request

- [x] adjusts the maximum duration in tests to reduce the pain of running tests