### PR TITLE
Enhancement: Configure `Ergebnis\PHPUnit\SlowTestDetector` as parent namespace prefix for `ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector`

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/phpunit-slow-test-detector
  */
 
+use Ergebnis\Rector;
 use Rector\Config;
 use Rector\ValueObject;
 
@@ -25,4 +26,10 @@ return static function (Config\RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->phpVersion(ValueObject\PhpVersion::PHP_70);
+
+    $rectorConfig->ruleWithConfiguration(Rector\Rules\Files\ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector::class, [
+        'parentNamespacePrefixes' => [
+            'Ergebnis\PHPUnit\SlowTestDetector',
+        ],
+    ]);
 };

--- a/src/Reporter/Console/ConsoleReporter.php
+++ b/src/Reporter/Console/ConsoleReporter.php
@@ -27,7 +27,7 @@ use Ergebnis\PHPUnit\SlowTestDetector\SlowTestList;
 final class ConsoleReporter implements Reporter\Reporter
 {
     /**
-     * @var DurationFormatter
+     * @var Reporter\Console\DurationFormatter
      */
     private $durationFormatter;
 
@@ -42,7 +42,7 @@ final class ConsoleReporter implements Reporter\Reporter
     private $maximumCount;
 
     public function __construct(
-        DurationFormatter $durationFormatter,
+        Reporter\Console\DurationFormatter $durationFormatter,
         MaximumDuration $maximumDuration,
         MaximumCount $maximumCount
     ) {
@@ -109,7 +109,7 @@ final class ConsoleReporter implements Reporter\Reporter
 
         yield '';
 
-        $unit = Unit::fromDurations(
+        $unit = Reporter\Console\Unit::fromDurations(
             $this->maximumDuration->toDuration(),
             ...\array_merge(
                 \array_map(static function (SlowTest $slowTest): Duration {
@@ -238,7 +238,7 @@ final class ConsoleReporter implements Reporter\Reporter
 
         yield '';
 
-        $unit = Unit::fromDurations(
+        $unit = Reporter\Console\Unit::fromDurations(
             $this->maximumDuration->toDuration(),
             ...\array_map(static function (SlowTest $slowTest): Duration {
                 return $slowTest->duration();
@@ -321,7 +321,7 @@ final class ConsoleReporter implements Reporter\Reporter
     }
 
     private function durationColumnWidth(
-        Unit $unit,
+        Reporter\Console\Unit $unit,
         Duration ...$durations
     ): int {
         return \max(
@@ -339,7 +339,7 @@ final class ConsoleReporter implements Reporter\Reporter
      * @return \Generator<int, string>
      */
     private function legend(
-        Unit $unit,
+        Reporter\Console\Unit $unit,
         int $columnStart,
         int $columnWidth
     ): \Generator {
@@ -360,7 +360,7 @@ final class ConsoleReporter implements Reporter\Reporter
 
         yield $padding . $durationOfZeroFormatted;
 
-        if ($unit->equals(Unit::hours())) {
+        if ($unit->equals(Reporter\Console\Unit::hours())) {
             yield $padding . ' │  │  └─── seconds';
 
             yield $padding . ' │  └────── minutes';
@@ -370,7 +370,7 @@ final class ConsoleReporter implements Reporter\Reporter
             return;
         }
 
-        if ($unit->equals(Unit::minutes())) {
+        if ($unit->equals(Reporter\Console\Unit::minutes())) {
             yield $padding . ' │  └─── seconds';
 
             yield $padding . ' └────── minutes';

--- a/src/SlowTestList.php
+++ b/src/SlowTestList.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\PHPUnit\SlowTestDetector;
 
-use Ergebnis\PHPUnit\SlowTestDetector\Comparator\DurationComparator;
-
 /**
  * @internal
  */
@@ -68,7 +66,7 @@ final class SlowTestList
 
     public function sortByDurationDescending(): self
     {
-        $durationComparator = new DurationComparator();
+        $durationComparator = new Comparator\DurationComparator();
 
         $slowTests = $this->slowTests;
 
@@ -84,7 +82,7 @@ final class SlowTestList
 
     public function sortByMaximumDurationDescending(): self
     {
-        $durationComparator = new DurationComparator();
+        $durationComparator = new Comparator\DurationComparator();
 
         $slowTests = $this->slowTests;
 

--- a/test/Unit/Reporter/Console/DurationFormatterTest.php
+++ b/test/Unit/Reporter/Console/DurationFormatterTest.php
@@ -44,7 +44,7 @@ final class DurationFormatterTest extends Framework\TestCase
     }
 
     /**
-     * @return \Generator<string, array{0: \Ergebnis\PHPUnit\SlowTestDetector\Reporter\Console\Unit, 1: Duration, 2: string}>
+     * @return \Generator<string, array{0: Reporter\Console\Unit, 1: Duration, 2: string}>
      */
     public static function provideDurationUnitAndFormattedDuration(): iterable
     {

--- a/test/Unit/Reporter/Console/UnitTest.php
+++ b/test/Unit/Reporter/Console/UnitTest.php
@@ -92,7 +92,7 @@ final class UnitTest extends Framework\TestCase
     }
 
     /**
-     * @return \Generator<string, array{0: \Ergebnis\PHPUnit\SlowTestDetector\Reporter\Console\Unit, 1: Duration}>
+     * @return \Generator<string, array{0: Reporter\Console\Unit, 1: Duration}>
      */
     public static function provideExpectedUnitAndDuration(): iterable
     {
@@ -146,7 +146,7 @@ final class UnitTest extends Framework\TestCase
     }
 
     /**
-     * @return \Generator<string, array{0: \Ergebnis\PHPUnit\SlowTestDetector\Reporter\Console\Unit, 1: list<Duration>}>
+     * @return \Generator<string, array{0: Reporter\Console\Unit, 1: list<Duration>}>
      */
     public static function provideExpectedUnitAndDurations(): iterable
     {


### PR DESCRIPTION
This pull request

- [x] configure `Ergebnis\PHPUnit\SlowTestDetector` as parent namespace prefix for `ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector`
- [x] runs `make refactoring`