### PR TITLE
Fix: Disable colors in end-to-end tests

### DIFF
--- a/test/EndToEnd/PHPUnit06/Console/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/Defaults/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumCount/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/MaximumDuration/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/Configuration/Stderr/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stderr="true"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/Bare/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/Combination/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAfterClassAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPostConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithAssertPreConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithBeforeClassAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithDataProvider/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUp/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDown/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestCase/WithoutTestMethods/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit06/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit06/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/Defaults/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumCount/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/MaximumDuration/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/Configuration/Stderr/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stderr="true"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/Bare/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/Combination/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAfterClassAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPostConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithAssertPreConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithBeforeClassAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithDataProvider/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUp/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDown/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestCase/WithoutTestMethods/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit07/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit07/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
-    colors="true"
+    colors="false"
     columns="max"
     forceCoversAnnotation="true"
     stopOnError="false"

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/Defaults/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumCount/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/MaximumDuration/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/Configuration/Stderr/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/Bare/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/Combination/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAfterClassAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPostConditions/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithAssertPreConditions/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithBeforeClassAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithDataProvider/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUp/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDown/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestCase/WithoutTestMethods/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit08/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit08/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/Defaults/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumCount/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/MaximumDuration/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/Configuration/Stderr/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/Bare/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/Combination/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAfterClassAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPostConditions/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithAssertPreConditions/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithBeforeClassAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithDataProvider/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUp/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDown/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestCase/WithoutTestMethods/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit09/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit09/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -7,7 +7,7 @@
     beStrictAboutTodoAnnotatedTests="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     executionOrder="default"
     forceCoversAnnotation="true"

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/Defaults/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumCount/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/MaximumDuration/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/Configuration/Stderr/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/Option/NoOutput/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/Option/NoOutput/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/Bare/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/Combination/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAfterClassAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPostConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithAssertPreConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithBeforeClassAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithDataProvider/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUp/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDown/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestCase/WithoutTestMethods/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestMethod/WithMaximumDurationAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestMethod/WithMaximumDurationAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestMethod/WithRunInSeparateProcessAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit10/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit10/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/Defaults/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumCount/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/MaximumDuration/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/Configuration/Stderr/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/Option/NoOutput/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/Option/NoOutput/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/Bare/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/Combination/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterClassAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAfterClassAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPostConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithAssertPreConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeClassAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithBeforeClassAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithDataProvider/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUp/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDown/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestCase/WithoutTestMethods/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestMethod/WithMaximumDurationAndSlowThresholdAnnotations/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestMethod/WithMaximumDurationAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestMethod/WithMaximumDurationAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestMethod/WithMaximumDurationAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestMethod/WithSlowThresholdAndMaximumDurationAnnotations/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit11/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
+++ b/test/EndToEnd/PHPUnit11/Console/TestMethod/WithSlowThresholdAnnotation/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/Defaults/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumCount/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/MaximumDuration/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/Configuration/Stderr/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/Option/NoOutput/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/Option/NoOutput/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/Bare/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/Combination/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterClassAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAfterClassAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPostConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithAssertPreConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeClassAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithBeforeClassAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithDataProvider/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUp/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDown/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestCase/WithoutTestMethods/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestMethod/WithMaximumDurationAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestMethod/WithMaximumDurationAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit12/Console/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit12/Console/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/Defaults/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/Defaults/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumCount/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumCount/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumDuration/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/MaximumDuration/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/Configuration/Stderr/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/Configuration/Stderr/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/Option/NoOutput/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/Option/NoOutput/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/Bare/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/Bare/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/Combination/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/Combination/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterClassAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAfterClassAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPostConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPostConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPreConditions/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithAssertPreConditions/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeClassAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithBeforeClassAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithDataProvider/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithDataProvider/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUp/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUp/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithSetUpBeforeClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDown/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDown/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDownAfterClass/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithTearDownAfterClass/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestCase/WithoutTestMethods/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestCase/WithoutTestMethods/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestMethod/WithMaximumDurationAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestMethod/WithMaximumDurationAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"

--- a/test/EndToEnd/PHPUnit13/Console/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
+++ b/test/EndToEnd/PHPUnit13/Console/TestMethod/WithRunInSeparateProcessAttribute/phpunit.xml
@@ -6,7 +6,7 @@
     beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="../../../../../../vendor/autoload.php"
     cacheResult="false"
-    colors="true"
+    colors="false"
     columns="max"
     displayDetailsOnIncompleteTests="true"
     displayDetailsOnSkippedTests="true"


### PR DESCRIPTION
This pull request

- [x] disables colors in end-to-end tests

Follows https://github.com/sebastianbergmann/phpunit/issues/5881.