### PR TITLE
Fix: Use self-repository syntax in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,7 @@ jobs:
   integrate:
     name: "Integrate"
 
-    uses: "./.github/workflows/integrate.yaml"
+    uses: "$/.github/workflows/integrate.yaml"
 
     secrets:
       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
This pull request

- [x] uses self-repository syntax in nightly workflow

Related to #893.