### PR TITLE
Fix: Remove `phpstan/phpstan-phpunit` when running unit tests and collecting code coverage

### DIFF
--- a/.docker/code-coverage.sh
+++ b/.docker/code-coverage.sh
@@ -5,7 +5,7 @@ set -o errexit
 cp --archive /app/src/. /app/work
 cd /app/work
 
-composer remove ergebnis/php-cs-fixer-config --ansi --dev --no-interaction --no-progress --quiet
+composer remove ergebnis/composer-normalize ergebnis/license ergebnis/php-cs-fixer-config ergebnis/rector-rules phpstan/extension-installer phpstan/phpstan phpstan/phpstan-deprecation-rules phpstan/phpstan-phpunit phpstan/phpstan-strict-rules rector/rector --ansi --dev --no-interaction --no-progress --quiet
 composer require phpunit/phpunit:^7.5.0 --ansi --no-interaction --no-progress --quiet --update-with-all-dependencies
 
 vendor/bin/phpunit --colors=always --configuration=test/Unit/phpunit.xml --coverage-text

--- a/.docker/tests-unit.sh
+++ b/.docker/tests-unit.sh
@@ -5,7 +5,7 @@ set -o errexit
 cp --archive /app/src/. /app/work
 cd /app/work
 
-composer remove ergebnis/php-cs-fixer-config --ansi --dev --no-interaction --no-progress --quiet
+composer remove ergebnis/composer-normalize ergebnis/license ergebnis/php-cs-fixer-config ergebnis/rector-rules phpstan/extension-installer phpstan/phpstan phpstan/phpstan-deprecation-rules phpstan/phpstan-phpunit phpstan/phpstan-strict-rules rector/rector --ansi --dev --no-interaction --no-progress --quiet
 composer require phpunit/phpunit:^7.5.0 --ansi --no-interaction --no-progress --quiet --update-with-all-dependencies
 
 vendor/bin/phpunit --colors=always --configuration=test/Unit/phpunit.xml


### PR DESCRIPTION
This pull request

- [x] removes `phpstan/phpstan-phpunit` when running unit tests and collecting code coverage

Follows https://github.com/ergebnis/phpunit-slow-test-detector/pull/856.
